### PR TITLE
feat: order team tags by name and fix revision detection for team cha…

### DIFF
--- a/data/radar/2017-03-01/team-diff.md
+++ b/data/radar/2017-03-01/team-diff.md
@@ -1,0 +1,9 @@
+---
+title: "Team Diff"
+ring: adopt
+quadrant: tools
+tags: [coding, frontend]
+teams: [team-b]
+---
+
+This is a demo entry. It is used to show how a radar item is written in Markdown format. The meta header is used to define the attributes of the item. The content of the file is used as the description of the item.

--- a/data/radar/2024-03-01/team-diff.md
+++ b/data/radar/2024-03-01/team-diff.md
@@ -1,0 +1,9 @@
+---
+title: "Team Diff"
+ring: adopt
+quadrant: tools
+tags: [coding, frontend]
+teams: [team-a, team-b]
+---
+
+This is a demo entry. It is used to show how a radar item is written in Markdown format. The meta header is used to define the attributes of the item. The content of the file is used as the description of the item.

--- a/scripts/buildData.ts
+++ b/scripts/buildData.ts
@@ -126,13 +126,7 @@ async function parseDirectory(dirPath: string): Promise<Item[]> {
   return Object.values(items).sort((a, b) => a.title.localeCompare(b.title));
 }
 
-function compareArrays({
-  arr1 = [],
-  arr2 = [],
-}: {
-  arr1?: any[];
-  arr2?: any[];
-}) {
+function compareArrays(arr1: any[], arr2: any[]) {
   return (
     arr1.length === arr2.length &&
     arr1.every((element, index) => element === arr2[index])
@@ -235,10 +229,7 @@ function postProcessItems(items: Item[]): {
           const { ring, body, teams } = revision;
           return (
             ring !== item.ring ||
-            !compareArrays({
-              arr1: teams,
-              arr2: item.teams,
-            }) ||
+            !compareArrays(teams ?? [], item.teams ?? []) ||
             (body != "" &&
               body != item.body &&
               body !== revisions[index - 1]?.body)

--- a/scripts/buildData.ts
+++ b/scripts/buildData.ts
@@ -96,7 +96,7 @@ async function parseDirectory(dirPath: string): Promise<Item[]> {
             tags: data.tags || [],
             revisions: [],
             position: [0, 0],
-            teams: data.teams || [],
+            teams: getOrderedTeams(data.teams) || [],
           };
         } else {
           items[id].release = releaseDate;
@@ -105,7 +105,7 @@ async function parseDirectory(dirPath: string): Promise<Item[]> {
           items[id].ring = data.ring || items[id].ring;
           items[id].quadrant = data.quadrant || items[id].quadrant;
           items[id].tags = data.tags || items[id].tags;
-          items[id].teams = data.teams || [];
+          items[id].teams = getOrderedTeams(data.teams) || [];
           items[id].featured =
             typeof data.featured === "boolean"
               ? data.featured
@@ -116,7 +116,7 @@ async function parseDirectory(dirPath: string): Promise<Item[]> {
           release: releaseDate,
           ring: data.ring,
           body,
-          teams: data.teams,
+          teams: getOrderedTeams(data.teams),
         });
       }
     }
@@ -124,6 +124,30 @@ async function parseDirectory(dirPath: string): Promise<Item[]> {
 
   await readDir(dirPath);
   return Object.values(items).sort((a, b) => a.title.localeCompare(b.title));
+}
+
+function compareArrays({
+  arr1 = [],
+  arr2 = [],
+}: {
+  arr1?: any[];
+  arr2?: any[];
+}) {
+  return (
+    arr1.length === arr2.length &&
+    arr1.every((element, index) => element === arr2[index])
+  );
+}
+
+function getOrderedTeams(listOfTeams: Item["teams"]): Item["teams"] {
+  if (!listOfTeams) return undefined;
+
+  const teams = new Set<string>();
+  for (const team of listOfTeams) {
+    teams.add(team);
+  }
+
+  return Array.from(teams).sort();
 }
 
 function getUniqueReleases(items: Item[]): string[] {
@@ -205,12 +229,16 @@ function postProcessItems(items: Item[]): {
       ...item,
       position: positioner.getNextPosition(item.quadrant, item.ring),
       flag: getFlag(item, releases),
-      // only keep revision which ring or body is different
+      // only keep revision which ring, body or team is different
       revisions: item.revisions
         ?.filter((revision, index, revisions) => {
-          const { ring, body } = revision;
+          const { ring, body, teams } = revision;
           return (
             ring !== item.ring ||
+            !compareArrays({
+              arr1: teams,
+              arr2: item.teams,
+            }) ||
             (body != "" &&
               body != item.body &&
               body !== revisions[index - 1]?.body)

--- a/scripts/buildData.ts
+++ b/scripts/buildData.ts
@@ -135,12 +135,8 @@ function compareArrays(arr1: any[] = [], arr2: any[] = []) {
 
 function getOrderedTeams(listOfTeams: Item["teams"]): Item["teams"] {
   if (!listOfTeams) return undefined;
-
-  const teams = new Set<string>();
-  for (const team of listOfTeams) {
-    teams.add(team);
-  }
-
+  // We use a Set to remove potentially duplicated entries
+  const teams = new Set<string>(listOfTeams);
   return Array.from(teams).sort();
 }
 

--- a/scripts/buildData.ts
+++ b/scripts/buildData.ts
@@ -126,7 +126,7 @@ async function parseDirectory(dirPath: string): Promise<Item[]> {
   return Object.values(items).sort((a, b) => a.title.localeCompare(b.title));
 }
 
-function compareArrays(arr1: any[], arr2: any[]) {
+function compareArrays(arr1: any[] = [], arr2: any[] = []) {
   return (
     arr1.length === arr2.length &&
     arr1.every((element, index) => element === arr2[index])
@@ -229,7 +229,7 @@ function postProcessItems(items: Item[]): {
           const { ring, body, teams } = revision;
           return (
             ring !== item.ring ||
-            !compareArrays(teams ?? [], item.teams ?? []) ||
+            !compareArrays(teams, item.teams) ||
             (body != "" &&
               body != item.body &&
               body !== revisions[index - 1]?.body)


### PR DESCRIPTION
## 📑 Description

Scenario: Only the teams attribute is changed

What happens: A change is detected and the label "changed" is rendered. Opening the technology's detail doesn't show any additional item on the list of changes.

What happens with this PR:  A change is detected and the label "changed" is rendered. Opening the technology's detail shows an additional item on the list of changes. Additionally, the team tags are now ordered alphabetically

## ✅ Checks
- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
