### PR TITLE
feat: redesign detail page with two-block layout and team diff visualization

### DIFF
--- a/data/config.default.json
+++ b/data/config.default.json
@@ -132,7 +132,7 @@
     "filterByTag": "Filter by Tag",
     "filterByTeam": "Filter by Team",
     "footer": "The technology radar is a project by AOE GmbH. Feel free to build your own radar based on the open source project.",
-    "notUpdated": "This item was not updated in last three versions of the Radar. Should it have appeared in one of the more recent editions, there is a good chance it remains pertinent. However, if the item dates back further, its relevance may have diminished and our current evaluation could vary. Regrettably, our capacity to consistently revisit items from past Radar editions is limited.",
+    "notUpdated": "This item was not updated in last three versions of the Radar.",
     "notFound": "404 - Page not found",
     "pageAbout": "How to use AOE Technology Radar?",
     "pageOverview": "Technologies Overview",

--- a/scripts/buildData.ts
+++ b/scripts/buildData.ts
@@ -118,6 +118,12 @@ async function parseDirectory(dirPath: string): Promise<Item[]> {
           release: releaseDate,
           ring: data.ring,
           body,
+          ...(items[id].revisions!.length > 0 &&
+            (body === "" ||
+              body ===
+                items[id].revisions![items[id].revisions!.length - 1].body) && {
+              bodyInherited: true,
+            }),
           teams: getOrderedTeams(data.teams),
         });
       }
@@ -140,6 +146,22 @@ function getOrderedTeams(listOfTeams: Item["teams"]): Item["teams"] {
   // We use a Set to remove potentially duplicated entries
   const teams = new Set<string>(listOfTeams);
   return Array.from(teams).sort();
+}
+
+function computeRevisionDiffs(revisions: Item["revisions"]): void {
+  if (!revisions || revisions.length < 2) return;
+  for (let i = 1; i < revisions.length; i++) {
+    const prevTeams = revisions[i - 1].teams || [];
+    const currTeams = revisions[i].teams || [];
+    const added = currTeams.filter((t) => !prevTeams.includes(t));
+    const removed = prevTeams.filter((t) => !currTeams.includes(t));
+    if (added.length > 0) revisions[i].addedTeams = added;
+    if (removed.length > 0) revisions[i].removedTeams = removed;
+    // Store previous ring for "trial → adopt" display in history
+    if (revisions[i].ring !== revisions[i - 1].ring) {
+      revisions[i].previousRing = revisions[i - 1].ring;
+    }
+  }
 }
 
 function getUniqueReleases(items: Item[]): string[] {
@@ -226,21 +248,35 @@ function postProcessItems(items: Item[]): {
 
   const releases = getUniqueReleases(filteredItems);
   const uniqueTags = getUniqueTags(filteredItems);
+
+  for (const item of filteredItems) {
+    computeRevisionDiffs(item.revisions);
+  }
+
   const processedItems = filteredItems.map((item) => {
+    const lastRevision = item.revisions?.[item.revisions.length - 1];
     const processedItem = {
       ...item,
       position: positioner.getNextPosition(item.quadrant, item.ring),
       flag: getFlag(item, releases),
+      ...(lastRevision?.addedTeams && { addedTeams: lastRevision.addedTeams }),
+      ...(lastRevision?.removedTeams && {
+        removedTeams: lastRevision.removedTeams,
+      }),
       // only keep revision which ring, body or team is different
       revisions: item.revisions
         ?.filter((revision, index, revisions) => {
-          const { ring, body, teams } = revision;
+          // always keep the first revision as the starting point
+          if (index === 0) return true;
+          const { ring, body } = revision;
+          const prev = revisions[index - 1];
+          const teamsChanged = prev
+            ? !compareArrays(revision.teams, prev.teams)
+            : false;
           return (
             ring !== item.ring ||
-            !compareArrays(teams, item.teams) ||
-            (body != "" &&
-              body != item.body &&
-              body !== revisions[index - 1]?.body)
+            teamsChanged ||
+            (body != "" && body != item.body && body !== prev?.body)
           );
         })
         .reverse(),

--- a/src/components/Icons/Description.tsx
+++ b/src/components/Icons/Description.tsx
@@ -1,0 +1,4 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+const SvgDescription = (props: SVGProps<SVGSVGElement>) => <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1={16} y1={13} x2={8} y2={13} /><line x1={16} y1={17} x2={8} y2={17} /><polyline points="10 9 9 9 8 9" /></svg>;
+export default SvgDescription;

--- a/src/components/Icons/RingChange.tsx
+++ b/src/components/Icons/RingChange.tsx
@@ -1,0 +1,4 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+const SvgRingChange = (props: SVGProps<SVGSVGElement>) => <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}><circle cx={12} cy={12} r={9} opacity={0.3} /><circle cx={12} cy={12} r={4} /><path d="M16.5 7.5 20 4m0 0-3.5.5M20 4l-.5 3.5" /></svg>;
+export default SvgRingChange;

--- a/src/components/ItemDetail/ItemDetail.module.css
+++ b/src/components/ItemDetail/ItemDetail.module.css
@@ -1,83 +1,195 @@
-.header {
+.tintZone {
+  position: relative;
+  background: color-mix(in oklch, var(--ring-color) 8%, transparent);
+  border-radius: 12px 12px 0 0;
+  padding: 30px;
+  margin-bottom: 0;
+}
+
+.tintZone::after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  height: 40px;
+  background: linear-gradient(
+    to bottom,
+    color-mix(in oklch, var(--ring-color) 8%, transparent),
+    transparent
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
+.bentoGrid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0;
+  border: 2px solid color-mix(in oklch, var(--ring-color) 40%, transparent);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.bentoCell {
+  padding: 20px;
+}
+
+.cellLeft {
+  border-right: 2px solid
+    color-mix(in oklch, var(--ring-color) 40%, transparent);
+  border-bottom: 2px solid
+    color-mix(in oklch, var(--ring-color) 40%, transparent);
+}
+
+.cellRight {
+  border-bottom: 2px solid
+    color-mix(in oklch, var(--ring-color) 40%, transparent);
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  margin: 0 0 20px;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.cellDescription {
+  grid-column: 1 / -1;
+  color: var(--foreground);
+}
+
+.ringName {
+  font-size: 48px;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--ring-color);
+  line-height: 1;
+}
+
+.quadrantLabel {
+  font-size: 14px;
+  color: var(--foreground);
+  opacity: 0.5;
+  margin-top: 4px;
+}
+
+.lastTransition {
+  font-size: 14px;
+  color: var(--foreground);
+  opacity: 0.4;
+  margin-top: 12px;
+}
+
+.tenure {
+  font-size: 12px;
+  color: var(--foreground);
+  opacity: 0.3;
+  margin-top: 8px;
 }
 
 .title {
-  margin: 0 30px 0 0;
+  font-size: 37px;
+  font-weight: 700;
+  color: var(--foreground);
+  margin: 0;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.tags :global(a) {
+  margin: 0;
+}
+
+.teamsContainer {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.description {
+  margin: 0;
+}
+
+.description :global(a) {
+  color: var(--link);
+  text-decoration: underline;
+}
+
+.description :global(a):hover {
+  text-decoration: none;
 }
 
 .editLink {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 15px;
+  right: 15px;
   display: block;
   width: 20px;
   height: 20px;
   opacity: 0;
   transition: opacity 0.2s;
+  z-index: 2;
 }
 
-/* Block 1: Current State */
-.currentState {
-  background: var(--content);
-  color: var(--text);
-  border-radius: 6px;
-  padding: 30px 15px;
-  position: relative;
-  margin-bottom: 40px;
-
-  &:hover {
-    .editLink {
-      opacity: 1;
-    }
-  }
+.tintZone:hover .editLink {
+  opacity: 1;
 }
 
-.currentState a {
-  color: var(--link);
-  text-decoration: underline;
-  &:hover {
-    text-decoration: none;
-  }
-}
-
-.currentStateRing {
-  margin-bottom: 15px;
-}
-
-.description {
-  margin: 15px 0;
-}
-
-.hint {
-  font-size: 14px;
-  background: var(--border);
-  color: var(--foreground);
-  border-radius: 6px;
-  padding: 15px;
-  margin-bottom: 15px;
+.cellHint {
+  grid-column: 1 / -1;
   display: flex;
   align-items: center;
   gap: 10px;
+  font-size: 14px;
+  color: var(--foreground);
+  border-bottom: 2px solid
+    color-mix(in oklch, var(--ring-color) 40%, transparent);
 }
 
 .notMaintainedIcon {
   fill: currentColor;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   flex-shrink: 0;
+  opacity: 0.7;
+}
+
+@media (max-width: 767px) {
+  .tintZone {
+    padding: 15px;
+  }
+  .bentoGrid {
+    grid-template-columns: 1fr;
+    gap: 0;
+    border: 2px solid color-mix(in oklch, var(--ring-color) 40%, transparent);
+  }
+  .cellLeft,
+  .cellRight {
+    border-right: none;
+    border-bottom: none;
+  }
+  .cellLeft {
+    order: 1;
+  }
+  .cellRight {
+    order: 2;
+  }
+  .cellDescription {
+    order: 3;
+  }
+  .ringName {
+    font-size: 36px;
+  }
 }
 
 /* Block 2: Change History — Flat Timeline */
-.historyHeading {
-  margin: 30px 0 20px;
-  font-size: 1.2em;
-}
 
 .timeline {
+  margin-top: 50px;
   position: relative;
   padding-left: 20px;
   margin-left: 8px;
@@ -115,13 +227,13 @@
 .dateLabel::before {
   content: "";
   position: absolute;
-  left: -20px;
   width: 9px;
   height: 9px;
   border-radius: 50%;
   background: var(--foreground);
   border: 2px solid var(--background);
-  transform: translateX(4px);
+  left: calc(-20px + 8px + 0.5px);
+  transform: translateX(-50%);
 }
 
 .dateLabelText {
@@ -215,14 +327,9 @@
   }
 }
 
-/* Expanded description — icon aligned top, full text flows beside */
-.descriptionFull {
-  display: flex;
+/* Expanded description — uses changeRow base with top-aligned icon */
+.changeRowExpanded {
   align-items: flex-start;
-  gap: 10px;
-  font-size: 16px;
-  color: var(--foreground);
-  line-height: 1.5;
 
   .changeIconDesc {
     margin-top: 2px;
@@ -233,6 +340,15 @@
   font-size: 16px;
   color: var(--foreground);
   line-height: 1.5;
+  min-width: 0;
+}
+
+.expandedBody :first-child {
+  margin-top: 0;
+}
+
+.expandedBody :last-child {
+  margin-bottom: 0;
 }
 
 .expandedBody a {
@@ -243,24 +359,14 @@
   }
 }
 
-/* Team change prefix (+/−) */
-.teamPrefix {
-  font-weight: 700;
-  font-size: 16px;
-}
-
-.teamPrefixAdded {
-  composes: teamPrefix;
-  color: rgba(34, 197, 94, 0.9);
-}
-
-.teamPrefixRemoved {
-  composes: teamPrefix;
-  color: rgba(239, 68, 68, 0.9);
-}
-
-/* Initial entry teams (muted pills) */
+/* Initial entry teams */
 .initialTeams {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.initialTeamsList {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
@@ -287,10 +393,6 @@
 }
 
 @media (min-width: 768px) {
-  .currentState {
-    padding: 30px;
-  }
-
   .timeline {
     padding-left: 30px;
     margin-left: 12px;
@@ -301,10 +403,9 @@
   }
 
   .dateLabel::before {
-    left: -30px;
+    left: calc(-30px + 12px + 0.5px);
     width: 11px;
     height: 11px;
-    transform: translateX(7px);
   }
 
   .descriptionPreview {

--- a/src/components/ItemDetail/ItemDetail.module.css
+++ b/src/components/ItemDetail/ItemDetail.module.css
@@ -20,10 +20,14 @@
   transition: opacity 0.2s;
 }
 
-.revision {
-  padding: 30px 0 15px 35px;
-  margin-left: 20px;
-  border-left: 1px solid var(--border);
+/* Block 1: Current State */
+.currentState {
+  background: var(--content);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 30px 15px;
+  position: relative;
+  margin-bottom: 40px;
 
   &:hover {
     .editLink {
@@ -32,43 +36,7 @@
   }
 }
 
-.release {
-  display: block;
-  text-align: center;
-  text-transform: uppercase;
-  font-size: 12px;
-  line-height: 1.2;
-  width: 50px;
-  height: 50px;
-  padding: 10px 0;
-  border-radius: 50%;
-  border: 1px solid var(--border);
-  background: var(--background);
-  float: left;
-  margin: -15px 0 0 -60px;
-}
-
-.notMaintainedIcon {
-  fill: currentColor;
-  width: 24px;
-  height: 24px;
-  margin: 8px auto;
-}
-
-.ring {
-  float: left;
-  margin: -45px 0 0 0;
-}
-
-.content {
-  position: relative;
-  background: var(--content);
-  color: var(--text);
-  border-radius: 6px;
-  padding: 30px 15px;
-}
-
-.content a {
+.currentState a {
   color: var(--link);
   text-decoration: underline;
   &:hover {
@@ -76,44 +44,270 @@
   }
 }
 
+.currentStateRing {
+  margin-bottom: 15px;
+}
+
+.description {
+  margin: 15px 0;
+}
+
+.hint {
+  font-size: 14px;
+  background: var(--border);
+  color: var(--foreground);
+  border-radius: 6px;
+  padding: 15px;
+  margin-bottom: 15px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.notMaintainedIcon {
+  fill: currentColor;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+/* Block 2: Change History — Flat Timeline */
+.historyHeading {
+  margin: 30px 0 20px;
+  font-size: 1.2em;
+}
+
+.timeline {
+  position: relative;
+  padding-left: 20px;
+  margin-left: 8px;
+}
+
+/* Vertical spine line */
+.timeline::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 8px;
+  width: 1px;
+  background: var(--border);
+}
+
+/* Date group */
+.dateGroup {
+  position: relative;
+  padding-bottom: 32px;
+}
+
+.dateGroup:last-child {
+  padding-bottom: 0;
+}
+
+/* Small circle on the timeline spine */
+.dateLabel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.dateLabel::before {
+  content: "";
+  position: absolute;
+  left: -20px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--foreground);
+  border: 2px solid var(--background);
+  transform: translateX(4px);
+}
+
+.dateLabelText {
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--foreground);
+}
+
+/* Change rows */
+.changeList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-left: 4px;
+}
+
+.changeRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 16px;
+  color: var(--foreground);
+  line-height: 1.5;
+}
+
+.changeIcon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  opacity: 0.7;
+}
+
+.changeIconRing {
+  composes: changeIcon;
+  color: var(--ring-color, var(--foreground));
+  opacity: 1;
+}
+
+.changeIconTeamAdded {
+  composes: changeIcon;
+  color: rgba(34, 197, 94, 0.9);
+}
+
+.changeIconTeamRemoved {
+  composes: changeIcon;
+  color: rgba(239, 68, 68, 0.9);
+}
+
+.changeIconDesc {
+  composes: changeIcon;
+  stroke: var(--foreground);
+  fill: none;
+  opacity: 1;
+}
+
+/* Ring transition row */
+.ringTransition {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ringArrow {
+  font-size: 18px;
+  color: var(--foreground);
+}
+
+/* Description truncation */
+.descriptionPreview {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 500px;
+  color: var(--foreground);
+}
+
+.moreLink {
+  color: var(--link);
+  text-decoration: none;
+  font-size: 14px;
+  white-space: nowrap;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+/* Expanded description — icon aligned top, full text flows beside */
+.descriptionFull {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 16px;
+  color: var(--foreground);
+  line-height: 1.5;
+
+  .changeIconDesc {
+    margin-top: 2px;
+  }
+}
+
+.expandedBody {
+  font-size: 16px;
+  color: var(--foreground);
+  line-height: 1.5;
+}
+
+.expandedBody a {
+  color: var(--link);
+  text-decoration: underline;
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+/* Team change prefix (+/−) */
+.teamPrefix {
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.teamPrefixAdded {
+  composes: teamPrefix;
+  color: rgba(34, 197, 94, 0.9);
+}
+
+.teamPrefixRemoved {
+  composes: teamPrefix;
+  color: rgba(239, 68, 68, 0.9);
+}
+
+/* Initial entry teams (muted pills) */
+.initialTeams {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+/* Edit link in history */
+.historyEditLink {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  transition: opacity 0.2s;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.dateGroup:hover .historyEditLink {
+  opacity: 0.5;
+}
+
+.historyEditLink:hover {
+  opacity: 1 !important;
+}
+
 @media (min-width: 768px) {
-  .revision {
-    padding: 30px 0 15px 50px;
-    margin-left: 38px;
-  }
-
-  .release {
-    font-size: 18px;
-    width: 75px;
-    height: 75px;
-    padding: 15px 0;
-    margin: -15px 0 0 -90px;
-  }
-
-  .ring {
-    margin-left: -15px;
-  }
-
-  .content {
+  .currentState {
     padding: 30px;
   }
-}
 
-/* special styles for revisions without content */
-.revision.noContent {
-  .content {
-    background: none;
+  .timeline {
+    padding-left: 30px;
+    margin-left: 12px;
   }
 
-  .ring {
-    margin-top: -20px;
+  .timeline::before {
+    left: 12px;
   }
-}
 
-.revision.hint {
-  .content {
-    font-size: 14px;
-    background: var(--border);
-    color: var(--foreground);
+  .dateLabel::before {
+    left: -30px;
+    width: 11px;
+    height: 11px;
+    transform: translateX(7px);
+  }
+
+  .descriptionPreview {
+    max-width: 700px;
   }
 }

--- a/src/components/ItemDetail/ItemDetail.tsx
+++ b/src/components/ItemDetail/ItemDetail.tsx
@@ -1,11 +1,19 @@
+import { useState } from "react";
+
 import styles from "./ItemDetail.module.css";
 
 import { RingBadge } from "@/components/Badge/Badge";
-import { Attention, Edit } from "@/components/Icons";
+import {
+  Attention,
+  Description,
+  Edit,
+  RingChange,
+  Team as TeamIcon,
+} from "@/components/Icons";
 import { Tag } from "@/components/Tags/Tags";
-import { Teams } from "@/components/Teams/Teams";
+import { Team, Teams } from "@/components/Teams/Teams";
 import { getEditUrl, getLabel, getReleases } from "@/lib/data";
-import { Item } from "@/lib/types";
+import { Item, Revision } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 const latestReleases = getReleases().slice(-3);
@@ -14,73 +22,179 @@ function isNotMaintained(release: string) {
   return !latestReleases.includes(release);
 }
 
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, "").trim();
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength).trimEnd() + "…";
+}
+
 interface ItemProps {
   item: Item;
 }
 
 export function ItemDetail({ item }: ItemProps) {
   const notMaintainedText = getLabel("notUpdated");
+  const editLink = getEditUrl({ id: item.id, release: item.release });
+  const hasHistory = item.revisions !== undefined && item.revisions.length > 0;
+
   return (
     <>
       <div className={styles.header}>
         <h1 className={styles.title}>{item.title}</h1>
         {item.tags?.map((tag) => <Tag key={tag} tag={tag} />)}
       </div>
-      <div className={styles.revisions}>
-        {notMaintainedText && isNotMaintained(item.release) && (
-          <div className={cn(styles.revision, styles.hint)}>
-            <span className={styles.release}>
-              <Attention className={styles.notMaintainedIcon} />
-            </span>
-            <div className={styles.content}>{notMaintainedText}</div>
-          </div>
+
+      {notMaintainedText && isNotMaintained(item.release) && (
+        <div className={styles.hint}>
+          <Attention className={styles.notMaintainedIcon} />
+          <span>{notMaintainedText}</span>
+        </div>
+      )}
+
+      <div className={styles.currentState}>
+        <div className={styles.currentStateRing}>
+          <RingBadge ring={item.ring} size="large" />
+        </div>
+        {item.body && (
+          <div
+            id="current-description"
+            className={styles.description}
+            dangerouslySetInnerHTML={{ __html: item.body }}
+          />
         )}
-        <Revision
-          id={item.id}
-          release={item.release}
-          ring={item.ring}
-          body={item.body}
-          teams={item.teams}
-        />
-        {item.revisions?.map((revision, index) => (
-          <Revision key={index} id={item.id} {...revision} />
-        ))}
-      </div>
-    </>
-  );
-}
-
-interface RevisionProps {
-  id: string;
-  release: string;
-  ring: string;
-  body?: string;
-  teams?: string[];
-}
-
-function Revision({ id, release, ring, body, teams }: RevisionProps) {
-  const date = new Date(release);
-  const editLink = getEditUrl({ id, release });
-  const formattedDate = date.toLocaleDateString("en-US", {
-    month: "short",
-    year: "numeric",
-  });
-  return (
-    <div className={cn(styles.revision, !body && styles.noContent)}>
-      <time dateTime={release} className={styles.release}>
-        {formattedDate}
-      </time>
-      <div className={styles.content}>
-        <RingBadge className={styles.ring} ring={ring} size="large" />
-        {body ? <div dangerouslySetInnerHTML={{ __html: body }} /> : null}
         {editLink && (
           <a href={editLink} target="_blank" className={styles.editLink}>
             <Edit />
           </a>
         )}
-        {!!teams && teams.length > 0 && (
-          <div className={styles.teams}>
-            <Teams teams={teams} />
+        {!!item.teams && item.teams.length > 0 && <Teams teams={item.teams} />}
+      </div>
+
+      {hasHistory && (
+        <>
+          <h2 className={styles.historyHeading}>History</h2>
+          <div className={styles.timeline}>
+            {item.revisions!.map((revision, index) => (
+              <HistoryDateGroup key={index} id={item.id} revision={revision} />
+            ))}
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+function ExpandableDescription({ body }: { body: string }) {
+  const plainText = stripHtml(body);
+  const needsTruncation = plainText.length > 100;
+  const [expanded, setExpanded] = useState(false);
+
+  if (!needsTruncation) {
+    return (
+      <div className={styles.changeRow}>
+        <Description className={styles.changeIconDesc} />
+        <span className={styles.descriptionPreview}>{plainText}</span>
+      </div>
+    );
+  }
+
+  if (expanded) {
+    return (
+      <div className={styles.descriptionFull}>
+        <Description className={styles.changeIconDesc} />
+        <div
+          className={styles.expandedBody}
+          dangerouslySetInnerHTML={{ __html: body }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.changeRow}>
+      <Description className={styles.changeIconDesc} />
+      <span className={styles.descriptionPreview}>
+        {truncate(plainText, 100)}
+      </span>
+      <button
+        type="button"
+        className={styles.moreLink}
+        onClick={() => setExpanded(true)}
+      >
+        more
+      </button>
+    </div>
+  );
+}
+
+interface HistoryDateGroupProps {
+  id: string;
+  revision: Revision;
+}
+
+function HistoryDateGroup({ id, revision }: HistoryDateGroupProps) {
+  const date = new Date(revision.release);
+  const formattedDate = date.toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+  });
+
+  const hasRingChange = !!revision.previousRing;
+  const hasBodyChange = !revision.bodyInherited && !!revision.body;
+  const hasAddedTeams = (revision.addedTeams?.length ?? 0) > 0;
+  const hasRemovedTeams = (revision.removedTeams?.length ?? 0) > 0;
+  const isInitialEntry = !hasRingChange && !hasAddedTeams && !hasRemovedTeams;
+
+  return (
+    <div className={styles.dateGroup}>
+      <div className={styles.dateLabel}>
+        <span className={styles.dateLabelText}>{formattedDate}</span>
+      </div>
+      <div className={styles.changeList}>
+        {hasRingChange ? (
+          <div className={styles.changeRow}>
+            <RingChange className={styles.changeIconRing} />
+            <div className={styles.ringTransition}>
+              <RingBadge ring={revision.previousRing!} />
+              <span className={styles.ringArrow}>→</span>
+              <RingBadge ring={revision.ring} />
+            </div>
+          </div>
+        ) : isInitialEntry ? (
+          <div className={styles.changeRow}>
+            <RingBadge ring={revision.ring} />
+          </div>
+        ) : null}
+
+        {hasBodyChange && <ExpandableDescription body={revision.body!} />}
+
+        {hasAddedTeams &&
+          revision.addedTeams!.map((team) => (
+            <div key={`added-${team}`} className={styles.changeRow}>
+              <TeamIcon className={styles.changeIconTeamAdded} />
+              <span className={styles.teamPrefixAdded}>+</span>
+              <Team team={team} />
+            </div>
+          ))}
+
+        {hasRemovedTeams &&
+          revision.removedTeams!.map((team) => (
+            <div key={`removed-${team}`} className={styles.changeRow}>
+              <TeamIcon className={styles.changeIconTeamRemoved} />
+              <span className={styles.teamPrefixRemoved}>−</span>
+              <Team team={team} />
+            </div>
+          ))}
+
+        {isInitialEntry && !!revision.teams && revision.teams.length > 0 && (
+          <div className={cn(styles.changeRow, styles.initialTeams)}>
+            <TeamIcon className={styles.changeIcon} />
+            {revision.teams.map((team) => (
+              <Team key={team} team={team} />
+            ))}
           </div>
         )}
       </div>

--- a/src/components/ItemDetail/ItemDetail.tsx
+++ b/src/components/ItemDetail/ItemDetail.tsx
@@ -1,18 +1,21 @@
-import { useState } from "react";
+import { CSSProperties, useState } from "react";
 
 import styles from "./ItemDetail.module.css";
 
 import { RingBadge } from "@/components/Badge/Badge";
 import {
   Attention,
-  Description,
+  DescriptionEdit,
   Edit,
   RingChange,
+  RingInitial,
+  TeamAdd,
   Team as TeamIcon,
+  TeamRemove,
 } from "@/components/Icons";
 import { Tag } from "@/components/Tags/Tags";
 import { Team, Teams } from "@/components/Teams/Teams";
-import { getEditUrl, getLabel, getReleases } from "@/lib/data";
+import { getEditUrl, getLabel, getReleases, getRing } from "@/lib/data";
 import { Item, Revision } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -33,49 +36,94 @@ function truncate(text: string, maxLength: number): string {
 
 interface ItemProps {
   item: Item;
+  quadrantTitle: string;
 }
 
-export function ItemDetail({ item }: ItemProps) {
+export function ItemDetail({ item, quadrantTitle }: ItemProps) {
   const notMaintainedText = getLabel("notUpdated");
   const editLink = getEditUrl({ id: item.id, release: item.release });
   const hasHistory = item.revisions !== undefined && item.revisions.length > 0;
 
+  const ringInfo = getRing(item.ring);
+  const ringColor = ringInfo?.color || "#fff";
+
+  // Tenure
+  const sortedRevisions = [...(item.revisions || [])].sort(
+    (a, b) => new Date(a.release).getTime() - new Date(b.release).getTime(),
+  );
+  const firstAssignedRevision = sortedRevisions.find(
+    (r) => r.ring === item.ring,
+  );
+  const tenureDate = firstAssignedRevision
+    ? new Date(firstAssignedRevision.release).toLocaleDateString("en-US", {
+        month: "short",
+        year: "numeric",
+      })
+    : null;
+
+  // Last Transition
+  const latestRevision = [...(item.revisions || [])].sort(
+    (a, b) => new Date(b.release).getTime() - new Date(a.release).getTime(),
+  )[0];
+  const lastTransition = latestRevision?.previousRing
+    ? `${getRing(latestRevision.previousRing)?.title || latestRevision.previousRing} → ${ringInfo?.title || item.ring}`
+    : null;
+
   return (
     <>
-      <div className={styles.header}>
-        <h1 className={styles.title}>{item.title}</h1>
-        {item.tags?.map((tag) => <Tag key={tag} tag={tag} />)}
-      </div>
-
-      {notMaintainedText && isNotMaintained(item.release) && (
-        <div className={styles.hint}>
-          <Attention className={styles.notMaintainedIcon} />
-          <span>{notMaintainedText}</span>
+      <div
+        className={styles.tintZone}
+        style={{ "--ring-color": ringColor } as CSSProperties}
+      >
+        <div className={styles.bentoGrid}>
+          {notMaintainedText && isNotMaintained(item.release) && (
+            <div className={cn(styles.bentoCell, styles.cellHint)}>
+              <Attention className={styles.notMaintainedIcon} />
+              <span>{notMaintainedText}</span>
+            </div>
+          )}
+          <div className={cn(styles.bentoCell, styles.cellLeft)}>
+            <div className={styles.ringName}>
+              {ringInfo?.title || item.ring}
+            </div>
+            <div className={styles.quadrantLabel}>{quadrantTitle}</div>
+            {lastTransition && (
+              <div className={styles.lastTransition}>{lastTransition}</div>
+            )}
+            {tenureDate && (
+              <div className={styles.tenure}>Since {tenureDate}</div>
+            )}
+          </div>
+          <div className={cn(styles.bentoCell, styles.cellRight)}>
+            <h1 className={styles.title}>{item.title}</h1>
+            <div className={styles.tags}>
+              {item.tags?.map((tag) => <Tag key={tag} tag={tag} />)}
+            </div>
+            {!!item.teams && item.teams.length > 0 && (
+              <div className={styles.teamsContainer}>
+                <Teams teams={item.teams} />
+              </div>
+            )}
+          </div>
+          {item.body && (
+            <div className={cn(styles.bentoCell, styles.cellDescription)}>
+              <div
+                id="current-description"
+                className={styles.description}
+                dangerouslySetInnerHTML={{ __html: item.body }}
+              />
+            </div>
+          )}
         </div>
-      )}
-
-      <div className={styles.currentState}>
-        <div className={styles.currentStateRing}>
-          <RingBadge ring={item.ring} size="large" />
-        </div>
-        {item.body && (
-          <div
-            id="current-description"
-            className={styles.description}
-            dangerouslySetInnerHTML={{ __html: item.body }}
-          />
-        )}
         {editLink && (
           <a href={editLink} target="_blank" className={styles.editLink}>
             <Edit />
           </a>
         )}
-        {!!item.teams && item.teams.length > 0 && <Teams teams={item.teams} />}
       </div>
 
       {hasHistory && (
         <>
-          <h2 className={styles.historyHeading}>History</h2>
           <div className={styles.timeline}>
             {item.revisions!.map((revision, index) => (
               <HistoryDateGroup key={index} id={item.id} revision={revision} />
@@ -95,7 +143,7 @@ function ExpandableDescription({ body }: { body: string }) {
   if (!needsTruncation) {
     return (
       <div className={styles.changeRow}>
-        <Description className={styles.changeIconDesc} />
+        <DescriptionEdit className={styles.changeIconDesc} />
         <span className={styles.descriptionPreview}>{plainText}</span>
       </div>
     );
@@ -103,8 +151,8 @@ function ExpandableDescription({ body }: { body: string }) {
 
   if (expanded) {
     return (
-      <div className={styles.descriptionFull}>
-        <Description className={styles.changeIconDesc} />
+      <div className={cn(styles.changeRow, styles.changeRowExpanded)}>
+        <DescriptionEdit className={styles.changeIconDesc} />
         <div
           className={styles.expandedBody}
           dangerouslySetInnerHTML={{ __html: body }}
@@ -115,7 +163,7 @@ function ExpandableDescription({ body }: { body: string }) {
 
   return (
     <div className={styles.changeRow}>
-      <Description className={styles.changeIconDesc} />
+      <DescriptionEdit className={styles.changeIconDesc} />
       <span className={styles.descriptionPreview}>
         {truncate(plainText, 100)}
       </span>
@@ -165,6 +213,7 @@ function HistoryDateGroup({ id, revision }: HistoryDateGroupProps) {
           </div>
         ) : isInitialEntry ? (
           <div className={styles.changeRow}>
+            <RingInitial className={styles.changeIconRing} />
             <RingBadge ring={revision.ring} />
           </div>
         ) : null}
@@ -174,8 +223,7 @@ function HistoryDateGroup({ id, revision }: HistoryDateGroupProps) {
         {hasAddedTeams &&
           revision.addedTeams!.map((team) => (
             <div key={`added-${team}`} className={styles.changeRow}>
-              <TeamIcon className={styles.changeIconTeamAdded} />
-              <span className={styles.teamPrefixAdded}>+</span>
+              <TeamAdd className={styles.changeIconTeamAdded} />
               <Team team={team} />
             </div>
           ))}
@@ -183,8 +231,7 @@ function HistoryDateGroup({ id, revision }: HistoryDateGroupProps) {
         {hasRemovedTeams &&
           revision.removedTeams!.map((team) => (
             <div key={`removed-${team}`} className={styles.changeRow}>
-              <TeamIcon className={styles.changeIconTeamRemoved} />
-              <span className={styles.teamPrefixRemoved}>−</span>
+              <TeamRemove className={styles.changeIconTeamRemoved} />
               <Team team={team} />
             </div>
           ))}
@@ -192,9 +239,11 @@ function HistoryDateGroup({ id, revision }: HistoryDateGroupProps) {
         {isInitialEntry && !!revision.teams && revision.teams.length > 0 && (
           <div className={cn(styles.changeRow, styles.initialTeams)}>
             <TeamIcon className={styles.changeIcon} />
-            {revision.teams.map((team) => (
-              <Team key={team} team={team} />
-            ))}
+            <div className={styles.initialTeamsList}>
+              {revision.teams.map((team) => (
+                <Team key={team} team={team} />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/src/components/Teams/Teams.module.css
+++ b/src/components/Teams/Teams.module.css
@@ -20,3 +20,20 @@
   overflow: hidden;
   text-decoration: none;
 }
+
+.teamAdded {
+  background-color: rgba(34, 197, 94, 0.3);
+  border: 1px solid rgba(34, 197, 94, 0.5);
+}
+
+.teamRemoved {
+  background-color: rgba(239, 68, 68, 0.3);
+  border: 1px solid rgba(239, 68, 68, 0.5);
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+
+.teamSmall {
+  padding: 4px 8px;
+  font-size: 9px;
+}

--- a/src/components/Teams/Teams.tsx
+++ b/src/components/Teams/Teams.tsx
@@ -5,11 +5,24 @@ import { cn } from "@/lib/utils";
 
 type TeamProps = {
   team: string;
+  variant?: "default" | "added" | "removed";
+  size?: "default" | "small";
 };
 
-export function Team({ team }: TeamProps) {
+export function Team({
+  team,
+  variant = "default",
+  size = "default",
+}: TeamProps) {
   return (
-    <div className={styles.team}>
+    <div
+      className={cn(
+        styles.team,
+        variant === "added" && styles.teamAdded,
+        variant === "removed" && styles.teamRemoved,
+        size === "small" && styles.teamSmall,
+      )}
+    >
       <span>{team}</span>
     </div>
   );
@@ -17,14 +30,31 @@ export function Team({ team }: TeamProps) {
 
 interface TeamsProps {
   teams: string[];
+  addedTeams?: string[];
+  removedTeams?: string[];
 }
 
-export function Teams({ teams }: TeamsProps) {
+export function Teams({
+  teams,
+  addedTeams = [],
+  removedTeams = [],
+}: TeamsProps) {
+  // Merge current teams + removed teams (so removed are visible with strikethrough)
+  const allTeams = [
+    ...teams,
+    ...removedTeams.filter((t) => !teams.includes(t)),
+  ].sort();
+
   return (
     <div className={cn(styles.teams)}>
-      {teams.map((team) => (
-        <Team key={team} team={team} />
-      ))}
+      {allTeams.map((team) => {
+        const variant = addedTeams.includes(team)
+          ? "added"
+          : removedTeams.includes(team)
+            ? "removed"
+            : "default";
+        return <Team key={team} team={team} variant={variant} />;
+      })}
     </div>
   );
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,8 +9,12 @@ export type Release = string;
 export interface Revision {
   release: Release;
   ring: string;
+  previousRing?: string;
   body?: string;
+  bodyInherited?: boolean;
   teams?: string[];
+  addedTeams?: string[];
+  removedTeams?: string[];
 }
 
 export interface Item {
@@ -27,6 +31,8 @@ export interface Item {
   revisions?: Revision[];
   position: [x: number, y: number];
   teams?: string[];
+  addedTeams?: string[];
+  removedTeams?: string[];
 }
 
 export interface Ring {

--- a/src/pages/[quadrant]/[id].module.css
+++ b/src/pages/[quadrant]/[id].module.css
@@ -2,10 +2,7 @@
   margin-bottom: 60px;
 }
 
-.ringAndQuadrant {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+.quadrantNav {
   padding-bottom: 20px;
   border-bottom: 1px solid var(--border);
 }

--- a/src/pages/[quadrant]/[id].tsx
+++ b/src/pages/[quadrant]/[id].tsx
@@ -4,7 +4,6 @@ import { useMemo } from "react";
 
 import styles from "./[id].module.css";
 
-import { RingBadge } from "@/components/Badge/Badge";
 import { ItemDetail } from "@/components/ItemDetail/ItemDetail";
 import { ItemList } from "@/components/ItemList/ItemList";
 import { QuadrantLink } from "@/components/QuadrantLink/QuadrantLink";
@@ -40,12 +39,11 @@ const ItemPage: CustomPage = () => {
 
       <div className={styles.layout}>
         <section className={styles.content}>
-          <ItemDetail item={item} />
+          <ItemDetail item={item} quadrantTitle={quadrant.title} />
         </section>
         <aside className={styles.sidebar}>
           <h3>{quadrant.title}</h3>
-          <div className={styles.ringAndQuadrant}>
-            <RingBadge ring={item.ring} />
+          <div className={styles.quadrantNav}>
             <QuadrantLink
               quadrant={quadrant}
               label={getLabel("quadrantOverview")}


### PR DESCRIPTION
## Summary

Redesigns the technology detail page to separate **current state** from **change history**, eliminating redundant description duplication when only teams change between releases.

## Problem

When a technology entry only adds/removes a team in a new release, the author had to copy the entire description into the new markdown file. The detail page would then show identical descriptions across multiple revisions, adding noise without information.

## Solution

### Block 1 — Current State (top)
Clean snapshot of the technology now: ring badge, full description, all teams as plain pills, edit link, not-maintained warning. No diffs, no timeline.

### Block 2 — Change History (below)
Flat timeline showing **only what changed** per release:
- **Ring transitions**: colored badge arrows (e.g. `Trial → Adopt`)
- **Description changes**: truncated preview with inline "more" expand
- **Team additions**: green icon + team badge
- **Team removals**: red icon + team badge
- **Initial entry**: always preserved as history starting point

### Data pipeline changes
- `bodyInherited` flag detects revisions with unchanged/empty descriptions
- `computeRevisionDiffs()` computes `addedTeams`, `removedTeams`, and `previousRing` between consecutive revisions
- Revision filter fixed to compare teams against **previous revision** (was comparing against final state, causing team-only changes to be filtered out)
- First revision always kept as starting point

## Files changed
- `src/lib/types.ts` — `previousRing`, `bodyInherited`, `addedTeams`, `removedTeams` on Revision + Item
- `scripts/buildData.ts` — diff computation + filter fix
- `src/components/Icons/RingChange.tsx` + `Description.tsx` — new SVG icons
- `src/components/ItemDetail/ItemDetail.tsx` — two-block layout rewrite
- `src/components/ItemDetail/ItemDetail.module.css` — flat timeline styles
- `src/components/Teams/Teams.tsx` + `.module.css` — variant/size props for diff badges