### PR TITLE
fix(techradar): respect NEXT_PUBLIC_BASE_PATH for asset URLs

### DIFF
--- a/packages/techradar/src/hooks/useSpotlightActions.ts
+++ b/packages/techradar/src/hooks/useSpotlightActions.ts
@@ -4,7 +4,6 @@ import { useMemo } from "react";
 import { exportRadarImage } from "@/lib/exportRadarImage";
 import { useTheme } from "@/lib/ThemeContext";
 import type { ThemeManifest, ThemePreferenceMode } from "@/lib/theme/schema";
-import { assetUrl } from "@/lib/utils";
 
 export type SpotlightAction = {
   id: string;
@@ -33,7 +32,7 @@ export function useSpotlightActions(
         hint: "Open the radar overview",
         keywords: ["home", "radar", "start", "overview"],
         perform: () => {
-          router.push(assetUrl("/")).catch(() => {});
+          router.push("/").catch(() => {});
           onAfterPerform();
         },
       },
@@ -43,7 +42,7 @@ export function useSpotlightActions(
         hint: "Open the changelog page",
         keywords: ["history", "changelog", "changes", "diff"],
         perform: () => {
-          router.push(assetUrl("/changelog")).catch(() => {});
+          router.push("/changelog").catch(() => {});
           onAfterPerform();
         },
       },
@@ -53,7 +52,7 @@ export function useSpotlightActions(
         hint: "Open the help and about page",
         keywords: ["about", "help", "info"],
         perform: () => {
-          router.push(assetUrl("/help-and-about-tech-radar")).catch(() => {});
+          router.push("/help-and-about-tech-radar").catch(() => {});
           onAfterPerform();
         },
       },

--- a/packages/techradar/src/lib/__tests__/utils.test.ts
+++ b/packages/techradar/src/lib/__tests__/utils.test.ts
@@ -69,6 +69,57 @@ describe("assetUrl with basePath", () => {
   });
 });
 
+// Regression (deploy fix): assetUrl() must read NEXT_PUBLIC_BASE_PATH first,
+// because the GitHub Pages deploy sets that env var rather than editing
+// data/config.json. Without env precedence, theme background images and other
+// raw asset URLs 404 on the deployed sub-path.
+describe("assetUrl with NEXT_PUBLIC_BASE_PATH env var", () => {
+  const originalEnv = process.env.NEXT_PUBLIC_BASE_PATH;
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_BASE_PATH;
+    } else {
+      process.env.NEXT_PUBLIC_BASE_PATH = originalEnv;
+    }
+    vi.resetModules();
+  });
+
+  it("uses NEXT_PUBLIC_BASE_PATH when set, overriding config.basePath", async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/porschedigital-technology-radar";
+    vi.resetModules();
+    vi.doMock("@/lib/config", () => ({
+      default: { basePath: "/something-else" },
+    }));
+    const { assetUrl: scopedAssetUrl } = await import("@/lib/utils");
+    expect(scopedAssetUrl("/themes/porsche/background-dark.jpg")).toBe(
+      "/porschedigital-technology-radar/themes/porsche/background-dark.jpg",
+    );
+    vi.doUnmock("@/lib/config");
+  });
+
+  it("treats NEXT_PUBLIC_BASE_PATH='/' as empty so root deploys are unprefixed", async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/";
+    vi.resetModules();
+    vi.doMock("@/lib/config", () => ({
+      default: { basePath: "/should-be-ignored" },
+    }));
+    const { assetUrl: scopedAssetUrl } = await import("@/lib/utils");
+    expect(scopedAssetUrl("/foo")).toBe("/foo");
+    vi.doUnmock("@/lib/config");
+  });
+
+  it("falls back to config.basePath when NEXT_PUBLIC_BASE_PATH is unset", async () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    vi.resetModules();
+    vi.doMock("@/lib/config", () => ({
+      default: { basePath: "/from-config" },
+    }));
+    const { assetUrl: scopedAssetUrl } = await import("@/lib/utils");
+    expect(scopedAssetUrl("/foo")).toBe("/from-config/foo");
+    vi.doUnmock("@/lib/config");
+  });
+});
+
 describe("readableTextOn", () => {
   it("returns white ink on dark light-theme segment colors so tooltip text remains legible", () => {
     expect(readableTextOn("#2D7A5C")).toBe("#FFFFFF");

--- a/packages/techradar/src/lib/utils.ts
+++ b/packages/techradar/src/lib/utils.ts
@@ -73,10 +73,15 @@ function parseHex(hex: string): [number, number, number] | null {
 export function assetUrl(path: string) {
   if (/^https?:/.test(path)) return path;
   if (!path.startsWith("/")) path = `/${path}`;
-  // Read basePath from the merged user/default config rather than next.config.js:
-  // importing next.config.js into src/ pulls its `require("node:path")` into the
-  // client bundle (webpack throws UnhandledSchemeError; Turbopack tree-shook it
-  // by accident). next.config.js itself derives basePath from the same config.
-  const base = config.basePath?.replace(/\/+$/, "") || "";
+  // Resolve basePath with the same precedence as next.config.js:
+  // NEXT_PUBLIC_BASE_PATH (deploy-time env, e.g. GitHub Pages) wins over the
+  // merged user/default config. Next inlines NEXT_PUBLIC_* into the client
+  // bundle at build time, so this works in SSG output too.
+  // We deliberately do NOT import next.config.js: it pulls `require("node:path")`
+  // into the client bundle (webpack throws UnhandledSchemeError; Turbopack
+  // tree-shook it by accident).
+  const envBase = process.env.NEXT_PUBLIC_BASE_PATH;
+  const rawBase = envBase != null ? envBase : config.basePath;
+  const base = rawBase?.replace(/\/+$/, "") || "";
   return `${base}${path}`;
 }

--- a/packages/techradar/src/pages/_document.tsx
+++ b/packages/techradar/src/pages/_document.tsx
@@ -15,7 +15,7 @@ import {
   type ThemeManifest,
   type ThemeModeValue,
 } from "@/lib/theme/schema";
-import { readableTextOn } from "@/lib/utils";
+import { assetUrl, readableTextOn } from "@/lib/utils";
 import rawThemes from "../../data/themes.generated.json";
 
 const themes = rawThemes as unknown as ThemeManifest[];
@@ -101,11 +101,11 @@ function backgroundVarsForMode(
   const image = theme.assetsResolved.image;
   let imageValue = "none";
   if (typeof image === "string") {
-    imageValue = `url("${image}")`;
+    imageValue = `url("${assetUrl(image)}")`;
   } else {
     const modeImage = resolveModeValue(image, mode);
     if (modeImage) {
-      imageValue = `url("${modeImage}")`;
+      imageValue = `url("${assetUrl(modeImage)}")`;
     }
   }
 


### PR DESCRIPTION
## Summary

Theme background images 404 on the deployed
[opensource.porsche.com/porschedigital-technology-radar/](https://opensource.porsche.com/porschedigital-technology-radar/)
because `assetUrl()` only ever consulted `config.basePath`, but the deploy
workflow sets `NEXT_PUBLIC_BASE_PATH=/porschedigital-technology-radar`
instead. The deployed HTML emits `--background-image: url(\"/themes/porsche/background-dark.jpg\")`
without the sub-path.

## Changes

- **`src/lib/utils.ts`** — `assetUrl()` now mirrors `next.config.js` precedence:
  reads `process.env.NEXT_PUBLIC_BASE_PATH` first, falls back to
  `config.basePath`, treats `\"/\"` as empty in both cases. The
  `NEXT_PUBLIC_*` prefix means Next inlines the value into the client bundle
  at build time (`check:build:no-node-builtins` confirms no Node built-ins
  leak in).
- **`src/pages/_document.tsx`** — wraps the two `url(\"\${image}\")` /
  `url(\"\${modeImage}\")` calls in `backgroundVarsForMode` with
  `assetUrl(...)`, per AGENTS.md (\"CSS asset URLs constructed in src/lib/
  must go through assetUrl()\").
- **`src/hooks/useSpotlightActions.ts`** — drops `assetUrl()` from the three
  `router.push()` calls. Per AGENTS.md, Next auto-prepends `basePath` for
  `useRouter().push()` and `<Link>`; wrapping with `assetUrl()` would double
  the prefix once env precedence is honoured. This was a latent bug that
  stayed dormant because `assetUrl()` had been a no-op.
- **`src/lib/__tests__/utils.test.ts`** — three new regression tests covering
  env-var precedence, `\"/\"`-collapses-to-empty, and config fallback.
  Save/restore env pattern via `originalEnv` + `afterEach`.

## DoD (all green locally, skip check:sec per worktree quirk)

- typecheck ✓ (both packages)
- test ✓ (techradar 544 tests, +3 new env tests; create-techradar 69 tests)
- lint ✓ (2 unrelated infos in create-techradar, pre-existing)
- check:arch ✓ (wikilinks + ADR uniqueness, 30 ADRs)
- check:quality ✓ (coverage stmts 82.16%, branches 76.68%, funcs 82.91%)
- check:a11y ✓ (eslint + axe, 36 HTML files)
- build ✓ + check:build ✓ (bundle 2629.5/2636.7 KB JS, 71.6/71.8 KB CSS,
  largest chunk 281.7/286.1 KB; HTML validate; no-node-builtins clean — env
  var doesn't pull node:process into client chunks)

## Reviewer notes

- The `_document.test.tsx` snapshots remain unchanged because in test env
  neither `NEXT_PUBLIC_BASE_PATH` nor `config.basePath` is set, so
  `assetUrl()` still returns paths unchanged.
- This is a `fix(techradar)` so release-please will produce a patch bump.