### PR TITLE
feat(techradar): make porsche-heritage backgrounds prominent

### DIFF
--- a/packages/techradar/data/themes/porsche-heritage/background-dark.svg
+++ b/packages/techradar/data/themes/porsche-heritage/background-dark.svg
@@ -1,15 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" preserveAspectRatio="xMidYMid slice">
   <defs>
-    <radialGradient id="g" cx="0.3" cy="0.7" r="0.85">
-      <stop offset="0%" stop-color="#D5001C" stop-opacity="0.28"/>
-      <stop offset="55%" stop-color="#0A0A0E" stop-opacity="0"/>
+    <radialGradient id="glow" cx="0.22" cy="0.78" r="0.95">
+      <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+      <stop offset="40%" stop-color="#7A1A26" stop-opacity="0.3"/>
+      <stop offset="80%" stop-color="#0A0A0E" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="halo" cx="0.85" cy="0.15" r="0.6">
+      <stop offset="0%" stop-color="#FFD60A" stop-opacity="0.25"/>
+      <stop offset="60%" stop-color="#0A0A0E" stop-opacity="0"/>
     </radialGradient>
   </defs>
   <rect width="1920" height="1080" fill="#0A0A0E"/>
-  <rect width="1920" height="1080" fill="url(#g)"/>
-  <g opacity="0.09">
-    <rect x="1700" y="0" width="3" height="1080" fill="#E63946"/>
-    <rect x="1720" y="0" width="3" height="1080" fill="#FFD60A"/>
-    <rect x="1740" y="0" width="3" height="1080" fill="#3DA0E0"/>
+  <rect width="1920" height="1080" fill="url(#glow)"/>
+  <rect width="1920" height="1080" fill="url(#halo)"/>
+  <g>
+    <rect x="120" y="0" width="32" height="1080" fill="#E63946" fill-opacity="0.7"/>
+    <rect x="172" y="0" width="14" height="1080" fill="#3DA0E0" fill-opacity="0.7"/>
+    <rect x="206" y="0" width="14" height="1080" fill="#FFD60A" fill-opacity="0.7"/>
+    <rect x="240" y="0" width="14" height="1080" fill="#A8C828" fill-opacity="0.7"/>
+  </g>
+  <g>
+    <rect x="1660" y="0" width="14" height="1080" fill="#A8C828" fill-opacity="0.55"/>
+    <rect x="1694" y="0" width="14" height="1080" fill="#FFD60A" fill-opacity="0.55"/>
+    <rect x="1728" y="0" width="14" height="1080" fill="#3DA0E0" fill-opacity="0.55"/>
+    <rect x="1762" y="0" width="32" height="1080" fill="#E63946" fill-opacity="0.55"/>
   </g>
 </svg>

--- a/packages/techradar/data/themes/porsche-heritage/background-light.svg
+++ b/packages/techradar/data/themes/porsche-heritage/background-light.svg
@@ -1,15 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" preserveAspectRatio="xMidYMid slice">
   <defs>
-    <radialGradient id="g" cx="0.7" cy="0.3" r="0.85">
-      <stop offset="0%" stop-color="#FFE5A8" stop-opacity="0.55"/>
-      <stop offset="55%" stop-color="#F2EEE8" stop-opacity="0"/>
+    <radialGradient id="glow" cx="0.78" cy="0.22" r="0.9">
+      <stop offset="0%" stop-color="#FFD27A" stop-opacity="0.85"/>
+      <stop offset="45%" stop-color="#F2C36A" stop-opacity="0.35"/>
+      <stop offset="80%" stop-color="#F2EEE8" stop-opacity="0"/>
     </radialGradient>
+    <linearGradient id="stripe" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-opacity="0.55"/>
+      <stop offset="50%" stop-opacity="0.85"/>
+      <stop offset="100%" stop-opacity="0.55"/>
+    </linearGradient>
   </defs>
   <rect width="1920" height="1080" fill="#F2EEE8"/>
-  <rect width="1920" height="1080" fill="url(#g)"/>
-  <g opacity="0.07">
-    <rect x="180" y="0" width="3" height="1080" fill="#D5001C"/>
-    <rect x="200" y="0" width="3" height="1080" fill="#C9A800"/>
-    <rect x="220" y="0" width="3" height="1080" fill="#0078C8"/>
+  <rect width="1920" height="1080" fill="url(#glow)"/>
+  <g>
+    <rect x="120" y="0" width="32" height="1080" fill="#D5001C" fill-opacity="0.55"/>
+    <rect x="172" y="0" width="14" height="1080" fill="#0078C8" fill-opacity="0.55"/>
+    <rect x="206" y="0" width="14" height="1080" fill="#C9A800" fill-opacity="0.55"/>
+    <rect x="240" y="0" width="14" height="1080" fill="#7BA31E" fill-opacity="0.55"/>
+  </g>
+  <g>
+    <rect x="1660" y="0" width="14" height="1080" fill="#7BA31E" fill-opacity="0.45"/>
+    <rect x="1694" y="0" width="14" height="1080" fill="#C9A800" fill-opacity="0.45"/>
+    <rect x="1728" y="0" width="14" height="1080" fill="#0078C8" fill-opacity="0.45"/>
+    <rect x="1762" y="0" width="32" height="1080" fill="#D5001C" fill-opacity="0.45"/>
   </g>
 </svg>

--- a/packages/techradar/data/themes/porsche-heritage/manifest.jsonc
+++ b/packages/techradar/data/themes/porsche-heritage/manifest.jsonc
@@ -13,8 +13,8 @@
       "dark": "background-dark.svg"
     },
     "opacity": {
-      "light": 0.1,
-      "dark": 0.25
+      "light": 0.4,
+      "dark": 0.55
     }
   },
 


### PR DESCRIPTION
## Summary

The Porsche Heritage theme background was barely visible. Two compounding causes:

- **Manifest opacity multipliers were outliers**: `light: 0.1`, `dark: 0.25` — well below peer themes (synthwave `0.28/0.45`, solarized `0.45/0.55`).
- **SVG content was anaemic**: a single radial gradient peaking at `0.55` alpha plus three 3px stripes huddled in a ~60px column near one edge with `0.07–0.09` group opacity. Effective on-screen alpha for the brightest pixel was `0.1 × 0.55 = 0.055` in light mode.

## Changes

`packages/techradar/data/themes/porsche-heritage/`

- `manifest.jsonc`: opacity multipliers → `light: 0.4`, `dark: 0.55` (peer-aligned with solarized).
- `background-light.svg` / `background-dark.svg`: redesigned as a classic motorsport hood-stripe motif. A wider Guards Red band flanked by Riviera Blue, Racing Yellow, and Acid Green accents on each side of the canvas, in-SVG fill alpha bumped to `0.45–0.7`, plus a second radial halo on dark mode for warmth.

## DoD

All green locally:

- typecheck, lint (2 unrelated infos in `create-techradar`), test (544 + 69)
- check:arch, check:quality (cov stmts 82.16%, branches 76.68%), check:a11y
- build, check:build (bundle 2629.5/2636.7 KB JS, 71.6/71.8 KB CSS, largest 281.7/286.1 KB; HTML validate; no-node-builtins clean)
- check:sec skipped locally (trufflehog worktree quirk — CI runs cleanly)

## Reviewer notes

- No code touched — pure data/theme assets. Other themes are untouched.
- No tests reference the heritage manifest values; existing `_document.test.tsx` snapshots use the `porsche` fixture and remain unaffected.
- Per release-please: this is a `feat` → next release will minor-bump.