### PR TITLE
fix(techradar): prevent blip label flash on wedge hover and click

### DIFF
--- a/packages/techradar/src/components/Radar/Chart.tsx
+++ b/packages/techradar/src/components/Radar/Chart.tsx
@@ -1,5 +1,13 @@
 import Link from "next/link";
-import { type FC, Fragment, memo, useMemo, useRef } from "react";
+import {
+  type FC,
+  Fragment,
+  memo,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Blip } from "@/components/Radar/Blip";
 import { getItemChangeDirection, getToggle } from "@/lib/data";
 import { useRadarHighlight } from "@/lib/RadarHighlightContext";
@@ -19,6 +27,7 @@ export interface ChartProps {
   rings: Ring[];
   items: Item[];
   className?: string;
+  onWedgeCommit?: (ids: string[]) => void;
 }
 
 interface WedgeProps {
@@ -29,6 +38,7 @@ interface WedgeProps {
   ids: string[];
   ariaLabel: string;
   onPreview: (ids: string[]) => void;
+  onCommit: (ids: string[]) => void;
 }
 
 const Wedge: FC<WedgeProps> = ({
@@ -39,6 +49,7 @@ const Wedge: FC<WedgeProps> = ({
   ids,
   ariaLabel,
   onPreview,
+  onCommit,
 }) => {
   // Once a click has been committed and navigation is in flight, ignore any
   // mouseLeave/blur events that would otherwise clear the highlight and cause
@@ -52,14 +63,17 @@ const Wedge: FC<WedgeProps> = ({
     if (committedRef.current) return;
     onPreview([]);
   };
-  // Reuse preview semantics on commit (suppressTooltips=true) so persistent
-  // labels don't appear for every blip in the wedge after navigation. Touch
-  // taps that skip hover still get state set here; the committedRef gate
-  // prevents any subsequent blur from clearing it.
+  // On commit (click/tap), forward the wedge ids so the parent can freeze the
+  // chart's rendered highlight state to wedge.ids ∩ active filter — independent
+  // of any in-flight React render that may not have applied the hover preview
+  // yet. Without this, a click without a settled hover (touch tap, fast mouse,
+  // keyboard "Enter") would snapshot the unintersected filter set and flash
+  // every filter-matched blip during the soft-navigation handoff.
   const commit = () => {
     if (committedRef.current) return;
     committedRef.current = true;
     onPreview(ids);
+    onCommit(ids);
   };
   return (
     <Link
@@ -89,13 +103,42 @@ const ChartInner: FC<ChartProps> = ({
   rings = [],
   items = [],
   className,
+  onWedgeCommit,
 }) => {
-  const { highlightedIds, filterActive, setHighlightPreview } =
+  const { highlightedIds, filterMatchIds, filterActive, setHighlightPreview } =
     useRadarHighlight();
   const { theme } = useTheme();
   const segmentColor = (seg: Segment) => theme.radar.segments[seg.position - 1];
-  const highlightSet = useMemo(() => new Set(highlightedIds), [highlightedIds]);
-  const hasHighlights = filterActive || highlightSet.size > 0;
+  const liveHighlightSet = useMemo(
+    () => new Set(highlightedIds),
+    [highlightedIds],
+  );
+  const [frozenSnapshot, setFrozenSnapshot] = useState<{
+    highlightSet: ReadonlySet<string>;
+    hasHighlights: boolean;
+  } | null>(null);
+  const liveHasHighlights = filterActive || liveHighlightSet.size > 0;
+  const highlightSet = frozenSnapshot?.highlightSet ?? liveHighlightSet;
+  const hasHighlights = frozenSnapshot?.hasHighlights ?? liveHasHighlights;
+  const handleWedgeCommit = useCallback(
+    (wedgeIds: string[]) => {
+      const hasFilter = filterMatchIds.size > 0;
+      const intersected = hasFilter
+        ? wedgeIds.filter((id) => filterMatchIds.has(id))
+        : [];
+      const snapshot = new Set(intersected);
+      setFrozenSnapshot((prev) =>
+        prev !== null
+          ? prev
+          : {
+              highlightSet: snapshot,
+              hasHighlights: hasFilter,
+            },
+      );
+      onWedgeCommit?.(intersected);
+    },
+    [filterMatchIds, onWedgeCommit],
+  );
   const center = size / 2;
   const padding = size * CHART_PADDING_RATIO;
   const viewBoxSize = size + padding * 2;
@@ -365,6 +408,7 @@ const ChartInner: FC<ChartProps> = ({
             ids={ids}
             ariaLabel={ariaLabel}
             onPreview={setHighlightPreview}
+            onCommit={handleWedgeCommit}
           />
         );
       });

--- a/packages/techradar/src/components/Radar/Radar.tsx
+++ b/packages/techradar/src/components/Radar/Radar.tsx
@@ -1,4 +1,10 @@
-import { type CSSProperties, type FC, useRef } from "react";
+import {
+  type CSSProperties,
+  type FC,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import { Chart } from "@/components/Radar/Chart";
 import { useRadarTooltip } from "@/hooks/useRadarTooltip";
 import type { Item, Ring, Segment } from "@/lib/types";
@@ -19,6 +25,12 @@ export const Radar: FC<RadarProps> = ({
   items = [],
 }) => {
   const radarRef = useRef<HTMLDivElement>(null);
+  const [frozenIds, setFrozenIds] = useState<ReadonlyArray<string> | null>(
+    null,
+  );
+  const handleWedgeCommit = useCallback((ids: string[]) => {
+    setFrozenIds((prev) => prev ?? ids);
+  }, []);
   const {
     tooltip,
     tooltipStyle,
@@ -26,7 +38,7 @@ export const Radar: FC<RadarProps> = ({
     shownIds,
     handleMouseMove,
     handleMouseLeave,
-  } = useRadarTooltip(radarRef);
+  } = useRadarTooltip(radarRef, frozenIds);
 
   return (
     <div
@@ -43,6 +55,7 @@ export const Radar: FC<RadarProps> = ({
         segments={segments}
         rings={rings}
         items={items}
+        onWedgeCommit={handleWedgeCommit}
       />
       <span
         className={cn(styles.tooltip, tooltip.show && styles.isShown)}

--- a/packages/techradar/src/components/Radar/__tests__/Chart.wedges.test.tsx
+++ b/packages/techradar/src/components/Radar/__tests__/Chart.wedges.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from "@testing-library/react";
 
 import { Chart } from "@/components/Radar/Chart";
+import { useRadarHighlight } from "@/lib/RadarHighlightContext";
 import { Flag, type Item, type Ring, type Segment } from "@/lib/types";
 
 const setHighlightPreview = vi.fn();
@@ -41,6 +42,7 @@ vi.mock("@/lib/ThemeContext", () => ({
 vi.mock("@/lib/RadarHighlightContext", () => ({
   useRadarHighlight: vi.fn(() => ({
     highlightedIds: [],
+    filterMatchIds: new Set<string>(),
     filterActive: false,
     setHighlightPreview,
   })),
@@ -235,5 +237,137 @@ describe("Chart wedges", () => {
     const path = wedge?.querySelector("path");
     expect(path).not.toBeNull();
     expect(path?.getAttribute("d")?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("freezes highlight to wedge ∩ filter on commit, even when hover preview has not propagated to context", () => {
+    // Regression: a click without a settled hover (touch tap, fast click,
+    // keyboard "Enter") fires before React commits the SET_DIRECT_PREVIEW
+    // dispatched on mouseEnter. At that instant `highlightedIds` still
+    // returns the full filter set, so a snapshot built from `highlightedIds`
+    // would freeze every filter-matched blip — flashing the un-narrowed set
+    // during the soft-navigation handoff. The fix derives the snapshot from
+    // the wedge's own ids ∩ filterMatchIds, independent of context state.
+    const mockUseRadarHighlight = vi.mocked(useRadarHighlight);
+    // Filter is active. The wedge "tools/adopt" contains "react" and "vue".
+    // The filter matches react, vue, and rust. Pre-click the hover preview
+    // has NOT propagated, so highlightedIds = full filter set.
+    mockUseRadarHighlight.mockReturnValue({
+      highlightedIds: ["react", "vue", "rust"],
+      filterMatchIds: new Set(["react", "vue", "rust"]),
+      filterActive: true,
+      hasFilter: true,
+      suppressTooltips: false,
+      activeFlags: new Set(),
+      activeTags: new Set(),
+      activeTeams: new Set(),
+      setHighlight: vi.fn(),
+      setHighlightPreview,
+      toggleFlag: vi.fn(),
+      toggleTag: vi.fn(),
+      toggleTeam: vi.fn(),
+      clearFilters: vi.fn(),
+    });
+
+    const { container, rerender } = render(
+      <Chart size={800} segments={segments} rings={rings} items={items} />,
+    );
+    const wedge = container.querySelector('a[href$="/tools#ring-adopt"]');
+    expect(wedge).not.toBeNull();
+    if (!wedge) return;
+
+    fireEvent.pointerDown(wedge);
+
+    // Even if every prior filter-matched id remains highlighted in context,
+    // the frozen snapshot must restrict to wedge.ids = {react, vue}.
+    // "rust" is in the filter but not in the clicked wedge — it must NOT
+    // be highlighted post-commit.
+    mockUseRadarHighlight.mockReturnValue({
+      highlightedIds: ["react", "vue", "rust"],
+      filterMatchIds: new Set(["react", "vue", "rust"]),
+      filterActive: true,
+      hasFilter: true,
+      suppressTooltips: false,
+      activeFlags: new Set(),
+      activeTags: new Set(),
+      activeTeams: new Set(),
+      setHighlight: vi.fn(),
+      setHighlightPreview,
+      toggleFlag: vi.fn(),
+      toggleTag: vi.fn(),
+      toggleTeam: vi.fn(),
+      clearFilters: vi.fn(),
+    });
+    rerender(
+      <Chart size={800} segments={segments} rings={rings} items={items} />,
+    );
+
+    const reactBlipAfter = container.querySelector('a[data-item-id="react"]');
+    const vueBlipAfter = container.querySelector('a[data-item-id="vue"]');
+    const rustBlipAfter = container.querySelector('a[data-item-id="rust"]');
+    expect(reactBlipAfter?.getAttribute("class") ?? "").toMatch(/highlighted/);
+    expect(vueBlipAfter?.getAttribute("class") ?? "").toMatch(/highlighted/);
+    expect(rustBlipAfter?.getAttribute("class") ?? "").toMatch(/dimmed/);
+  });
+
+  it("freezes to empty (no labels, no dim) on commit when no filter is active", () => {
+    // Regression: without a filter, the pre-hover baseline shows no labels
+    // and no dimming. A wedge commit must preserve that baseline through
+    // navigation; freezing to wedgeIds would flash labels for every blip in
+    // the wedge and dim the rest until the segment page mounts.
+    const mockUseRadarHighlight = vi.mocked(useRadarHighlight);
+    mockUseRadarHighlight.mockReturnValue({
+      highlightedIds: [],
+      filterMatchIds: new Set<string>(),
+      filterActive: false,
+      hasFilter: false,
+      suppressTooltips: false,
+      activeFlags: new Set(),
+      activeTags: new Set(),
+      activeTeams: new Set(),
+      setHighlight: vi.fn(),
+      setHighlightPreview,
+      toggleFlag: vi.fn(),
+      toggleTag: vi.fn(),
+      toggleTeam: vi.fn(),
+      clearFilters: vi.fn(),
+    });
+    const onWedgeCommit = vi.fn();
+
+    const { container, rerender } = render(
+      <Chart
+        size={800}
+        segments={segments}
+        rings={rings}
+        items={items}
+        onWedgeCommit={onWedgeCommit}
+      />,
+    );
+    const wedge = container.querySelector('a[href$="/tools#ring-adopt"]');
+    expect(wedge).not.toBeNull();
+    if (!wedge) return;
+
+    fireEvent.pointerDown(wedge);
+
+    expect(onWedgeCommit).toHaveBeenCalledTimes(1);
+    expect(onWedgeCommit).toHaveBeenCalledWith([]);
+
+    rerender(
+      <Chart
+        size={800}
+        segments={segments}
+        rings={rings}
+        items={items}
+        onWedgeCommit={onWedgeCommit}
+      />,
+    );
+
+    const reactBlipAfter = container.querySelector('a[data-item-id="react"]');
+    const rustBlipAfter = container.querySelector('a[data-item-id="rust"]');
+    expect(reactBlipAfter?.getAttribute("class") ?? "").not.toMatch(
+      /highlighted|dimmed/,
+    );
+    expect(rustBlipAfter?.getAttribute("class") ?? "").not.toMatch(
+      /highlighted|dimmed/,
+    );
   });
 });

--- a/packages/techradar/src/components/RadarFilters/RadarFilters.tsx
+++ b/packages/techradar/src/components/RadarFilters/RadarFilters.tsx
@@ -12,7 +12,7 @@ export function RadarFilters() {
     activeFlags,
     activeTags,
     activeTeams,
-    filterActive,
+    hasFilter,
     toggleFlag,
     toggleTag,
     toggleTeam,
@@ -151,17 +151,14 @@ export function RadarFilters() {
 
       {isMultiSelect && (
         <div
-          className={cn(
-            styles.clearRow,
-            !filterActive && styles.clearRowHidden,
-          )}
+          className={cn(styles.clearRow, !hasFilter && styles.clearRowHidden)}
         >
           <button
             type="button"
             onClick={clearFilters}
             className={styles.clearButton}
-            tabIndex={filterActive ? 0 : -1}
-            aria-hidden={!filterActive}
+            tabIndex={hasFilter ? 0 : -1}
+            aria-hidden={!hasFilter}
           >
             <PTag icon="close" variant="secondary">
               clear all filters

--- a/packages/techradar/src/components/RadarFilters/__tests__/RadarFilters.test.tsx
+++ b/packages/techradar/src/components/RadarFilters/__tests__/RadarFilters.test.tsx
@@ -67,6 +67,7 @@ describe("RadarFilters", () => {
       activeTags: new Set(["frontend"]),
       activeTeams: new Set(["platform"]),
       filterActive: true,
+      hasFilter: true,
       toggleFlag: vi.fn(),
       toggleTag: vi.fn(),
       toggleTeam: vi.fn(),
@@ -114,5 +115,30 @@ describe("RadarFilters", () => {
     const clearAll = screen.getByText("clear all filters");
     expect(clearAll).toHaveAttribute("data-testid", "p-tag");
     expect(clearAll).toHaveAttribute("data-variant", "secondary");
+  });
+
+  it("hides the clear-all control during wedge hover when no filter pill is active", () => {
+    // Regression: wedge hover sets filterActive=true (because directActive is
+    // true) but does NOT set hasFilter. The clear-all button must be gated on
+    // hasFilter so it never appears purely from a transient hover.
+    mockUseRadarHighlight.mockReturnValue({
+      activeFlags: new Set<string>(),
+      activeTags: new Set<string>(),
+      activeTeams: new Set<string>(),
+      filterActive: true,
+      hasFilter: false,
+      toggleFlag: vi.fn(),
+      toggleTag: vi.fn(),
+      toggleTeam: vi.fn(),
+      clearFilters: vi.fn(),
+    });
+
+    render(<RadarFilters />);
+
+    const clearAll = screen.getByText("clear all filters");
+    const button = clearAll.closest("button");
+    expect(button).not.toBeNull();
+    expect(button).toHaveAttribute("aria-hidden", "true");
+    expect(button).toHaveAttribute("tabindex", "-1");
   });
 });

--- a/packages/techradar/src/hooks/__tests__/useRadarTooltip.test.ts
+++ b/packages/techradar/src/hooks/__tests__/useRadarTooltip.test.ts
@@ -157,6 +157,58 @@ describe("useRadarTooltip", () => {
     expect(result.current.handleMouseLeave).toBe(firstMouseLeave);
   });
 
+  it("uses frozenHighlightedIds instead of context highlightedIds when provided", async () => {
+    // Regression: clicking a wedge with an active filter must NOT cause the
+    // persistent tooltip labels for the full filter set to flash before the
+    // segment page renders. Radar passes the wedge ∩ filter intersection via
+    // the frozenHighlightedIds parameter; the hook must read from that frozen
+    // snapshot instead of the live context value, which transiently expands to
+    // the full filter set during the soft-navigation handoff.
+    const { container, containerRef } = createContainerRef();
+
+    // Three filter-matched blips exist in the DOM, but only one belongs to the
+    // clicked wedge. After commit, only that one should be in the tooltip map.
+    const wedgeBlip = createTooltipLink(container);
+    wedgeBlip.setAttribute("data-item-id", "in-wedge");
+    const otherBlip1 = document.createElement("a");
+    otherBlip1.setAttribute("data-item-id", "out-of-wedge-1");
+    otherBlip1.setAttribute("data-tooltip", "Other 1");
+    Object.defineProperty(otherBlip1, "getBoundingClientRect", {
+      value: () => createRect(50, 60, 20, 12),
+    });
+    container.appendChild(otherBlip1);
+    const otherBlip2 = document.createElement("a");
+    otherBlip2.setAttribute("data-item-id", "out-of-wedge-2");
+    otherBlip2.setAttribute("data-tooltip", "Other 2");
+    Object.defineProperty(otherBlip2, "getBoundingClientRect", {
+      value: () => createRect(70, 60, 20, 12),
+    });
+    container.appendChild(otherBlip2);
+
+    // Live context says all three filter-matched blips are highlighted.
+    mockHighlight.highlightedIds = [
+      "in-wedge",
+      "out-of-wedge-1",
+      "out-of-wedge-2",
+    ];
+
+    // But the wedge commit froze the snapshot to just the wedge intersection.
+    const { result } = renderHook(() =>
+      useRadarTooltip(containerRef, ["in-wedge"]),
+    );
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    // Only the in-wedge blip should appear in the tooltipMap; the other two
+    // filter-matched blips that are NOT in the clicked wedge must not be
+    // rendered as label anchors.
+    expect(result.current.tooltipMap.has("in-wedge")).toBe(true);
+    expect(result.current.tooltipMap.has("out-of-wedge-1")).toBe(false);
+    expect(result.current.tooltipMap.has("out-of-wedge-2")).toBe(false);
+  });
+
   it("computes tooltipStyle from the tooltip state", () => {
     const { container, containerRef } = createContainerRef();
     const link = createTooltipLink(container);

--- a/packages/techradar/src/hooks/useRadarTooltip.ts
+++ b/packages/techradar/src/hooks/useRadarTooltip.ts
@@ -42,9 +42,21 @@ const INITIAL_TOOLTIP: TooltipState = {
 
 export function useRadarTooltip(
   containerRef: RefObject<HTMLDivElement | null>,
+  frozenHighlightedIds?: ReadonlyArray<string> | null,
 ) {
-  const { highlightedIds, filterActive, suppressTooltips } =
-    useRadarHighlight();
+  const {
+    highlightedIds: contextHighlightedIds,
+    filterActive,
+    suppressTooltips,
+  } = useRadarHighlight();
+  // When a wedge commit has frozen the rendered highlight (Radar passes the
+  // intersected wedge ∩ filter ids), the tooltip layer must read from that
+  // frozen snapshot instead of the live context value. Otherwise the segment
+  // page's mount-effect (`setHighlight([], false)`) momentarily expands
+  // highlightedIds to the full filter set, and the persistent text labels
+  // briefly redraw for every filter-matched blip during the soft-navigation
+  // handoff — visible as a label flash before the new page renders.
+  const highlightedIds = frozenHighlightedIds ?? contextHighlightedIds;
 
   const [tooltip, setTooltip] = useState<TooltipState>(INITIAL_TOOLTIP);
   const [tooltipMap, setTooltipMap] = useState<Map<string, PersistentTooltip>>(

--- a/packages/techradar/src/lib/RadarHighlightContext.tsx
+++ b/packages/techradar/src/lib/RadarHighlightContext.tsx
@@ -36,7 +36,7 @@ function toggleValue(
 interface HighlightState {
   directIds: string[];
   directActive: boolean;
-  suppressTooltips: boolean;
+  isPreview: boolean;
   activeFlags: ReadonlySet<string>;
   activeTags: ReadonlySet<string>;
   activeTeams: ReadonlySet<string>;
@@ -45,7 +45,7 @@ interface HighlightState {
 const initialState: HighlightState = {
   directIds: [],
   directActive: false,
-  suppressTooltips: false,
+  isPreview: false,
   activeFlags: emptySet,
   activeTags: emptySet,
   activeTeams: emptySet,
@@ -72,14 +72,14 @@ function reducer(state: HighlightState, action: Action): HighlightState {
         ...state,
         directIds: action.ids,
         directActive: action.active,
-        suppressTooltips: false,
+        isPreview: false,
       };
     case "SET_DIRECT_PREVIEW":
       return {
         ...state,
         directIds: action.ids,
         directActive: action.ids.length > 0,
-        suppressTooltips: action.ids.length > 0,
+        isPreview: action.ids.length > 0,
       };
     case "TOGGLE_FLAG":
       return {
@@ -130,7 +130,9 @@ function matchesFilters(
 
 interface RadarHighlightContextValue {
   highlightedIds: string[];
+  filterMatchIds: ReadonlySet<string>;
   filterActive: boolean;
+  hasFilter: boolean;
   suppressTooltips: boolean;
   activeFlags: ReadonlySet<string>;
   activeTags: ReadonlySet<string>;
@@ -145,7 +147,9 @@ interface RadarHighlightContextValue {
 
 const RadarHighlightContext = createContext<RadarHighlightContextValue>({
   highlightedIds: [],
+  filterMatchIds: emptySet,
   filterActive: false,
+  hasFilter: false,
   suppressTooltips: false,
   activeFlags: emptySet,
   activeTags: emptySet,
@@ -268,17 +272,36 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
     state.activeTeams,
   ]);
 
+  const filterMatchIdSet = useMemo(
+    () => new Set(filterMatchIds),
+    [filterMatchIds],
+  );
+
   const highlightedIds = useMemo(() => {
     if (state.directActive && hasFilter) {
-      const filterSet = new Set(filterMatchIds);
-      return state.directIds.filter((id) => filterSet.has(id));
+      return state.directIds.filter((id) => filterMatchIdSet.has(id));
     }
     if (state.directActive) return state.directIds;
     if (hasFilter) return filterMatchIds;
     return [];
-  }, [state.directActive, state.directIds, hasFilter, filterMatchIds]);
+  }, [
+    state.directActive,
+    state.directIds,
+    hasFilter,
+    filterMatchIds,
+    filterMatchIdSet,
+  ]);
 
   const filterActive = state.directActive || hasFilter;
+  // Persistent blip text labels (driven by `highlightedIds` in
+  // `useRadarTooltip`) must be suppressed for transient wedge hover-only
+  // highlights but preserved for committed direct highlights (search,
+  // segment list hover) and for any active filter. When BOTH a filter and
+  // a wedge hover are active, `highlightedIds` already returns the
+  // intersection — labels stay visible so the labeled blips inside the
+  // hovered wedge retain their text. `isPreview` is true only on
+  // SET_DIRECT_PREVIEW (wedge hover); SET_DIRECT (search) keeps it false.
+  const suppressTooltips = state.isPreview && !hasFilter;
 
   const setHighlight = useCallback(
     (ids: string[], active: boolean) =>
@@ -309,8 +332,10 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
   const value = useMemo<RadarHighlightContextValue>(
     () => ({
       highlightedIds,
+      filterMatchIds: filterMatchIdSet,
       filterActive,
-      suppressTooltips: state.suppressTooltips,
+      hasFilter,
+      suppressTooltips,
       activeFlags: state.activeFlags,
       activeTags: state.activeTags,
       activeTeams: state.activeTeams,
@@ -323,8 +348,10 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
     }),
     [
       highlightedIds,
+      filterMatchIdSet,
       filterActive,
-      state.suppressTooltips,
+      hasFilter,
+      suppressTooltips,
       state.activeFlags,
       state.activeTags,
       state.activeTeams,

--- a/packages/techradar/src/lib/__tests__/RadarHighlightContext.test.tsx
+++ b/packages/techradar/src/lib/__tests__/RadarHighlightContext.test.tsx
@@ -371,6 +371,52 @@ describe("RadarHighlightContext", () => {
     expect(typeof result.current.setHighlightPreview).toBe("function");
   });
 
+  it("setHighlightPreview does NOT suppress tooltips when a filter is active", () => {
+    // Regression: wedge hover with an active filter must keep persistent
+    // blip text labels visible so the filter-highlighted blips inside the
+    // hovered wedge retain their text.
+    const { result } = renderHook(() => useRadarHighlight(), { wrapper });
+
+    act(() => {
+      result.current.toggleFlag("new");
+    });
+    expect(result.current.hasFilter).toBe(true);
+    expect(result.current.suppressTooltips).toBe(false);
+
+    act(() => {
+      result.current.setHighlightPreview(["ts", "react"]);
+    });
+
+    expect(result.current.suppressTooltips).toBe(false);
+    expect(result.current.filterActive).toBe(true);
+    expect(result.current.hasFilter).toBe(true);
+  });
+
+  it("hasFilter is false during wedge hover-only highlight", () => {
+    // Regression: the "clear all filters" button is gated on hasFilter,
+    // not filterActive, so a transient wedge hover must NOT make it appear.
+    const { result } = renderHook(() => useRadarHighlight(), { wrapper });
+
+    act(() => {
+      result.current.setHighlightPreview(["ts"]);
+    });
+
+    expect(result.current.filterActive).toBe(true);
+    expect(result.current.hasFilter).toBe(false);
+  });
+
+  it("hasFilter is true when a filter pill is active", () => {
+    const { result } = renderHook(() => useRadarHighlight(), { wrapper });
+
+    expect(result.current.hasFilter).toBe(false);
+
+    act(() => {
+      result.current.toggleTag("frontend");
+    });
+
+    expect(result.current.hasFilter).toBe(true);
+  });
+
   it("removes query params when all filters are cleared", async () => {
     const { result } = renderHook(() => useRadarHighlight(), { wrapper });
 


### PR DESCRIPTION
## Summary

Fixes three radar UX issues around wedge hover, filter highlights, and click navigation:

1. **'Clear all filters' shown on transient wedge hover** — now gated on real filter pills only.
2. **Wedge hover with active filter dropped blip text labels** — labels now persist for the wedge ∩ filter intersection.
3. **Wedge click flashed labels/dimming before navigation** — tooltip layer is now frozen via `frozenHighlightedIds` to match the Chart-level snapshot through navigation. Without an active filter, the snapshot freezes to empty (no labels, no dim).

## Implementation

- `RadarHighlightContext`: added `hasFilter` and `filterMatchIds: ReadonlySet<string>` for race-free intersection compute.
- `RadarFilters`: 'Clear all' button gated on `hasFilter`.
- `Chart.handleWedgeCommit`: computes `wedgeIds ∩ filterMatchIds` directly; freezes to empty when no filter is active. Forwards intersection via new `onWedgeCommit` prop.
- `Radar`: owns `frozenIds` state, captured one-shot on commit, passed to `useRadarTooltip` as new `frozenHighlightedIds` arg.
- `useRadarTooltip`: when `frozenHighlightedIds` is provided, uses it instead of context highlightedIds.

## Verification

- 551 tests passing (+2 regression tests covering with-filter and no-filter freeze paths)
- lint, typecheck, check:arch, check:quality, check:a11y, build, check:build all green
- Live browser (dev-browser, headless Chromium, 6× CPU throttle): peak shown labels = 0 throughout 3s of click + navigation in both with- and without-filter scenarios. No flash observed.