### PR TITLE
fix(techradar): honor theme manifest default + scaffold themes to top-level folder

### DIFF
--- a/packages/techradar/README.md
+++ b/packages/techradar/README.md
@@ -127,7 +127,7 @@ All configuration lives in `data/config.json`. Any key you omit falls back to th
 | `baseUrl`           | Full origin (scheme + host) where the radar is hosted, e.g. `https://opensource.porsche.com`. Used for `sitemap.xml`, canonical links, and Open Graph / Twitter meta tags. The runtime env var `NEXT_PUBLIC_BASE_URL` overrides this when set (useful for staging deploys). The `basePath` is appended automatically — do **not** include it here. | `""`    |
 | `editUrl`           | If set, shows an edit button on item pages. Supports `{id}` and `{release}` placeholders. Example: `https://github.dev/org/repo/blob/main/data/radar/{release}/{id}.md` | `"https://github.dev/porscheofficial/porschedigital-technology-radar/blob/main/data/radar/{release}/{id}.md"` |
 | `jsFile`            | Path in `public/` or URL to a custom JavaScript file to include on every page.                     | `""`    |
-| `defaultTheme`      | Identifier of the theme applied on first visit. Must match the `id` of a theme in `data/themes/<id>/manifest.jsonc`. You may optionally pin the initial mode with `theme:light` or `theme:dark`; otherwise dual-mode themes start in `system` mode and single-mode themes use their only supported mode. Visitors can switch theme and mode at runtime via Spotlight, and the selection is persisted in `localStorage`. | `"porsche"` |
+| `defaultTheme`      | Identifier of the theme applied on first visit. Must match the `id` of a theme in `themes/<id>/manifest.jsonc`. The initial mode comes from that manifest's `default` field; you may override it by pinning `theme:light`, `theme:dark`, or `theme:system` (e.g. `"porsche:system"` to follow the OS preference). Visitors can switch theme and mode at runtime via Spotlight, and the selection is persisted in `localStorage`. | `"porsche"` |
 | `imprint`           | URL to your legal information / imprint page.                                                      | `""` |
 
 </details>
@@ -234,7 +234,9 @@ An array of social link objects shown in the footer.
 ### Theming
 
 The Radar now uses a folder-per-theme architecture where each theme declares the
-supported modes inside `data/themes/<theme>/manifest.jsonc`.
+supported modes inside `themes/<theme>/manifest.jsonc`. Consumer themes live at
+the top of the project (sibling of `radar/`); built-in themes shipped with the
+package are scaffolded there on `npx techradar init`.
 
 - `supports: ["light", "dark"]` enables the header sun/moon toggle and the
   Spotlight `Mode:` actions.
@@ -244,7 +246,7 @@ supported modes inside `data/themes/<theme>/manifest.jsonc`.
 - Theme selection is persisted in `localStorage` under `techradar-theme`.
 
 There is no migration CLI for the old flat `colorScheme` schema. Rewrite legacy
-`manifest.jsonc` files by hand using `data/themes/.example/`.
+`manifest.jsonc` files by hand using `themes/.example/`.
 
 #### Theme assets
 

--- a/packages/techradar/bin/__tests__/init-theme-copy.test.ts
+++ b/packages/techradar/bin/__tests__/init-theme-copy.test.ts
@@ -1,7 +1,7 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("init theme scaffolding", () => {
   let tempDir: string;
@@ -21,5 +21,35 @@ describe("init theme scaffolding", () => {
     expect(
       existsSync(path.resolve("data", "themes", "porsche", "manifest.jsonc")),
     ).toBe(true);
+  });
+
+  // Regression: themes were scaffolded into `<consumer>/data/themes/` (hidden
+  // alongside generated build inputs) and never synced into `.techradar/`,
+  // so consumer edits had zero effect. They must land at top-level `themes/`
+  // (sibling of `radar/`) and be copied into `.techradar/data/themes/` on each
+  // build via syncThemesToBuildDir().
+  it("scaffolds themes into top-level <consumer>/themes/, not data/themes/", () => {
+    const binSource = readFileSync(path.resolve("bin", "techradar.ts"), "utf8");
+    expect(binSource).toMatch(/scaffold\(\s*join\(CWD, "themes", theme\)/);
+    expect(binSource).not.toMatch(
+      /scaffold\(\s*join\(CWD, "data", "themes", theme\)/,
+    );
+  });
+
+  it("syncs <consumer>/themes/ into the shadow build's data/themes/", () => {
+    const binSource = readFileSync(path.resolve("bin", "techradar.ts"), "utf8");
+    expect(binSource).toContain("function syncThemesToBuildDir");
+    expect(binSource).toMatch(/syncThemesToBuildDir\(\)/);
+    expect(binSource).toMatch(
+      /cpSync\(consumerThemes, themesBuild, \{ recursive: true \}\)/,
+    );
+  });
+
+  it("watches <consumer>/themes/ in dev mode", () => {
+    const binSource = readFileSync(path.resolve("bin", "techradar.ts"), "utf8");
+    expect(binSource).toMatch(/const themesDir = join\(CWD, "themes"\)/);
+    expect(binSource).toMatch(
+      /watch\(\s*\[radarDir, themesDir, aboutFile, customFile, configFile\]/,
+    );
   });
 });

--- a/packages/techradar/bin/techradar.ts
+++ b/packages/techradar/bin/techradar.ts
@@ -291,9 +291,9 @@ function bootstrap(): void {
       .sort();
     for (const theme of themeDirs) {
       scaffold(
-        join(CWD, "data", "themes", theme),
+        join(CWD, "themes", theme),
         join(themesSourceDir, theme),
-        `data/themes/${theme}/`,
+        `themes/${theme}/`,
         true,
       );
     }
@@ -321,6 +321,23 @@ function syncFilesToBuildDir(): void {
     join(CWD, "config.json"),
     join(BUILDER_DIR, "data", "config.json"),
   );
+  syncThemesToBuildDir();
+}
+
+// Consumer themes live at `<consumer>/themes/<id>/` (top-level, like `radar/`)
+// and must be copied into `.techradar/data/themes/<id>/` because the shadow
+// build expects the package layout. Without this sync the consumer's edits
+// have zero effect — the shadow keeps the built-in themes from `cpSync(SOURCE)`
+// in `ensureBuildDir()`. We replace the entire `data/themes` directory rather
+// than overlay so deleting a consumer theme actually removes it from the build.
+function syncThemesToBuildDir(): void {
+  const consumerThemes = join(CWD, "themes");
+  if (!existsSync(consumerThemes)) return;
+  const themesBuild = join(BUILDER_DIR, "data", "themes");
+  if (existsSync(themesBuild)) {
+    rmSync(themesBuild, { recursive: true });
+  }
+  cpSync(consumerThemes, themesBuild, { recursive: true });
 }
 
 function buildData(flags: string[] = []): void {
@@ -429,6 +446,7 @@ const devCommand = defineCommand({
     const child = startDevServer("async");
 
     const radarDir = join(CWD, "radar");
+    const themesDir = join(CWD, "themes");
     const aboutFile = join(CWD, "about.md");
     const customFile = join(CWD, "custom.scss");
     const configFile = join(CWD, "config.json");
@@ -471,6 +489,10 @@ const devCommand = defineCommand({
               rmSync(radarBuild, { recursive: true });
             }
             cpSync(radarDir, radarBuild, { recursive: true });
+          } else if (changedPath.startsWith(themesDir)) {
+            const relative = changedPath.replace(themesDir, "");
+            consola.info(`themes${relative} changed, syncing themes…`);
+            syncThemesToBuildDir();
           } else {
             consola.info("File changed");
           }
@@ -482,12 +504,15 @@ const devCommand = defineCommand({
       }, DEBOUNCE_MS);
     }
 
-    const watcher = watch([radarDir, aboutFile, customFile, configFile], {
-      persistent: true,
-      ignoreInitial: true,
-      depth: 5,
-      ignored: (path: string) => path.startsWith("."),
-    });
+    const watcher = watch(
+      [radarDir, themesDir, aboutFile, customFile, configFile],
+      {
+        persistent: true,
+        ignoreInitial: true,
+        depth: 5,
+        ignored: (path: string) => path.startsWith("."),
+      },
+    );
 
     watcher
       .on("add", debouncedRebuild)

--- a/packages/techradar/src/__tests__/pages/_document.test.tsx
+++ b/packages/techradar/src/__tests__/pages/_document.test.tsx
@@ -2,7 +2,11 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ThemeManifest } from "@/lib/theme/schema";
-import { buildThemeStyleBlock } from "@/pages/_document";
+import {
+  buildThemeStyleBlock,
+  getDefaultMode,
+  getSchemeClassForMode,
+} from "@/pages/_document";
 
 const dualModeTheme: ThemeManifest = {
   id: "porsche",
@@ -153,6 +157,42 @@ describe("buildThemeStyleBlock", () => {
     expect(css).toMatch(
       /--rtk-chip-team-removed-fg: light-dark\(#[0-9A-F]{6}, #[0-9A-F]{6}\)/,
     );
+  });
+});
+
+describe("getDefaultMode + getSchemeClassForMode (regression: manifest.default ignored)", () => {
+  const singleModeDark: ThemeManifest = {
+    ...dualModeTheme,
+    id: "acme",
+    supports: ["dark"],
+    default: "dark",
+  };
+
+  it("returns the manifest default for a dual-mode theme when no mode is pinned", () => {
+    expect(getDefaultMode(dualModeTheme, "porsche")).toBe("dark");
+    expect(
+      getSchemeClassForMode(getDefaultMode(dualModeTheme, "porsche")),
+    ).toBe("scheme-dark");
+  });
+
+  it("opts in to system mode when ':system' is pinned on a dual-mode theme", () => {
+    expect(getDefaultMode(dualModeTheme, "porsche:system")).toBe("system");
+    expect(
+      getSchemeClassForMode(getDefaultMode(dualModeTheme, "porsche:system")),
+    ).toBe("scheme-light-dark");
+  });
+
+  it("respects an explicit ':light' or ':dark' pin", () => {
+    expect(getDefaultMode(dualModeTheme, "porsche:light")).toBe("light");
+    expect(getDefaultMode(dualModeTheme, "porsche:dark")).toBe("dark");
+  });
+
+  it("falls back to manifest.default if pinned mode is unsupported", () => {
+    expect(getDefaultMode(singleModeDark, "acme:light")).toBe("dark");
+  });
+
+  it("collapses ':system' on single-mode themes to the only supported mode", () => {
+    expect(getDefaultMode(singleModeDark, "acme:system")).toBe("dark");
   });
 });
 

--- a/packages/techradar/src/lib/ThemeContext.tsx
+++ b/packages/techradar/src/lib/ThemeContext.tsx
@@ -239,8 +239,15 @@ function isPreferenceMode(
   return value === "light" || value === "dark" || value === "system";
 }
 
+// When the consumer doesn't pin a mode in `config.defaultTheme` (e.g. just
+// `"porsche"` instead of `"porsche:system"`), we honor the theme manifest's
+// `default` field. Previously dual-mode themes silently overrode this to
+// `"system"`, which made `manifest.default` a dead field and forced first-time
+// visitors of e.g. Porsche (default `"dark"`) to land on whatever their OS
+// preference said. Consumers who *want* OS-driven mode can opt in with
+// `defaultTheme: "porsche:system"`.
 function getDefaultPreferenceMode(theme: ThemeManifest): ThemePreferenceMode {
-  return theme.supports.length === 2 ? "system" : theme.default;
+  return theme.default;
 }
 
 function getSchemeClassName(

--- a/packages/techradar/src/lib/__tests__/ThemeContext.test.tsx
+++ b/packages/techradar/src/lib/__tests__/ThemeContext.test.tsx
@@ -108,11 +108,35 @@ beforeEach(() => {
 });
 
 describe("ThemeContext", () => {
-  it("exposes theme and mode state", () => {
+  it("uses the manifest default mode for dual-mode themes when no mode is pinned", () => {
     const { result } = renderHook(() => useTheme(), { wrapper });
     expect(result.current.theme.id).toBe("porsche");
-    expect(result.current.mode).toBe("system");
+    expect(result.current.mode).toBe("dark");
     expect(result.current.themes).toHaveLength(2);
+  });
+
+  it("opts in to system mode when defaultTheme pins ':system'", () => {
+    function systemWrapper({ children }: { children: ReactNode }) {
+      return (
+        <ThemeProvider themes={themes} initialThemeId="porsche:system">
+          {children}
+        </ThemeProvider>
+      );
+    }
+    const { result } = renderHook(() => useTheme(), { wrapper: systemWrapper });
+    expect(result.current.mode).toBe("system");
+  });
+
+  it("respects an explicit ':light' mode pin in initialThemeId", () => {
+    function lightWrapper({ children }: { children: ReactNode }) {
+      return (
+        <ThemeProvider themes={themes} initialThemeId="porsche:light">
+          {children}
+        </ThemeProvider>
+      );
+    }
+    const { result } = renderHook(() => useTheme(), { wrapper: lightWrapper });
+    expect(result.current.mode).toBe("light");
   });
 
   it("setActiveTheme persists the theme and updates document state", () => {

--- a/packages/techradar/src/pages/_document.tsx
+++ b/packages/techradar/src/pages/_document.tsx
@@ -21,8 +21,9 @@ import rawThemes from "../../data/themes.generated.json";
 const themes = rawThemes as unknown as ThemeManifest[];
 const defaultTheme = getDefaultTheme(themes, config.defaultTheme);
 const defaultThemeId = defaultTheme.id;
-const defaultSchemeClass = getDefaultSchemeClass(defaultTheme);
-const THEME_INIT_SCRIPT = `(function(){try{var d=document.documentElement;var b=localStorage.getItem('techradar-theme')||'${defaultThemeId}';var m=localStorage.getItem('techradar-mode')||'system';d.setAttribute('data-theme',b);d.classList.remove('scheme-light','scheme-dark','scheme-light-dark');if(m==='light'){d.classList.add('scheme-light');}else if(m==='dark'){d.classList.add('scheme-dark');}else{d.classList.add('scheme-light-dark');}}catch(e){}})();`;
+const defaultMode = getDefaultMode(defaultTheme, config.defaultTheme);
+const defaultSchemeClass = getSchemeClassForMode(defaultMode);
+const THEME_INIT_SCRIPT = `(function(){try{var d=document.documentElement;var b=localStorage.getItem('techradar-theme')||'${defaultThemeId}';var m=localStorage.getItem('techradar-mode')||'${defaultMode}';d.setAttribute('data-theme',b);d.classList.remove('scheme-light','scheme-dark','scheme-light-dark');if(m==='light'){d.classList.add('scheme-light');}else if(m==='dark'){d.classList.add('scheme-dark');}else{d.classList.add('scheme-light-dark');}}catch(e){}})();`;
 
 export function buildThemeStyleBlock(allThemes: ThemeManifest[]): string {
   return allThemes.map((theme) => buildThemeBlock(theme)).join("\n");
@@ -199,12 +200,29 @@ function getDefaultTheme(
   return themes.find((theme) => theme.id === themeId) ?? themes[0];
 }
 
-function getDefaultSchemeClass(
+export function getDefaultMode(
   theme: ThemeManifest,
-): "scheme-light" | "scheme-dark" | "scheme-light-dark" {
-  if (theme.supports.length === 2) {
-    return "scheme-light-dark";
+  defaultThemeId: string,
+): "light" | "dark" | "system" {
+  const [, rawMode] = defaultThemeId.split(":");
+  if (rawMode === "light" || rawMode === "dark" || rawMode === "system") {
+    if (rawMode === "system" && theme.supports.length === 1) {
+      return theme.supports[0];
+    }
+    if (
+      (rawMode === "light" || rawMode === "dark") &&
+      !theme.supports.includes(rawMode)
+    ) {
+      return theme.default;
+    }
+    return rawMode;
   }
+  return theme.default;
+}
 
-  return theme.default === "light" ? "scheme-light" : "scheme-dark";
+export function getSchemeClassForMode(
+  mode: "light" | "dark" | "system",
+): "scheme-light" | "scheme-dark" | "scheme-light-dark" {
+  if (mode === "system") return "scheme-light-dark";
+  return mode === "light" ? "scheme-light" : "scheme-dark";
 }


### PR DESCRIPTION
## Summary

Two consumer-facing theme bugs, both surfaced by a Porsche consumer project.

### Bug 1 - Manifest `default` mode silently ignored

`defaultTheme: "porsche"` (manifest declares `default: "dark"`, supports `["light", "dark"]`) initialized the UI in `system` mode and SSR'd `<html class="scheme-light-dark">`. The `manifest.default` field was effectively dead for any dual-mode theme.

**Fix:** `getDefaultPreferenceMode` now returns `theme.default` unconditionally. Consumers who want OS-following behavior opt in explicitly via `defaultTheme: "porsche:system"`. `_document.tsx` is refactored so SSR class and the pre-hydration `localStorage` fallback share one source of truth (`getDefaultMode` + `getSchemeClassForMode`).

End-to-end verified in built `out/index.html`:
- `<html class="scheme-dark">` (was `scheme-light-dark`)
- `techradar-mode')||'dark'` in init script (was `||'system'`)

### Bug 2 - Themes scaffolded to hidden `data/themes/`, never synced

`techradar init` placed built-in themes under `<consumer>/data/themes/` - inconsistent with the documented top-level layout (`radar/`, `config.json`, etc. all live at the root). Worse, `syncFilesToBuildDir` never copied themes into the shadow build, so any consumer edits to themes had **zero runtime effect**.

**Fix:**
- Scaffold themes to `<consumer>/themes/<id>/` (sibling of `radar/`)
- New `syncThemesToBuildDir` helper, wired into `syncFilesToBuildDir`
- `dev` watcher now watches `<consumer>/themes/` so live edits trigger rebuilds
- README updated for the corrected layout and semantics

## Test plan

- New `ThemeContext.test.tsx` cases: dual-mode no pin -> `dark`, `:system` pin -> `system`, `:light` pin -> `light`
- New `_document.test.tsx` `getDefaultMode + getSchemeClassForMode` block (5 cases): default fallback, all three pin modes, unsupported pin fallback, `:system` collapse on single-mode themes
- New `init-theme-copy.test.ts` source-string regression assertions: scaffold path, sync helper presence, dev watcher coverage
- Full DoD harness: lint, typecheck, test (556/556), check:arch, check:quality, check:a11y, build, check:build - all green