### PR TITLE
feat(techradar): add v1 to v2 migration tooling

### DIFF
--- a/packages/techradar/MIGRATION.md
+++ b/packages/techradar/MIGRATION.md
@@ -1,0 +1,337 @@
+# Migration Guide
+
+This document covers upgrading **consumer projects** (forks and projects that
+install `@porscheofficial/porschedigital-technology-radar` as a dependency)
+across breaking releases.
+
+If you maintain the framework itself, see `CHANGELOG.md` for the full release
+history and `docs/decisions/` (workspace root) for the architectural rationale
+behind each change.
+
+---
+
+## v1 → v2
+
+Two breaking changes ship in v2:
+
+1. **Quadrants were renamed to segments** — soft, shimmed with a deprecation
+   warning. Affects `config.json` and every Markdown frontmatter under
+   `radar/`.
+2. **Inline color theming was replaced by per-theme manifest files** under
+   `themes/<id>/manifest.jsonc`. Hard break: the build now throws on the
+   removed config keys and requires a new `defaultTheme` field.
+
+A full v1 → v2 upgrade has three steps (Section 1 → 2 → 3 below). Steps 1 and
+2 are mechanical; step 3 is the only one that takes any thought.
+
+### Start here: `npx techradar migrate`
+
+Before reading the rest of this guide, run the detector against your project:
+
+```bash
+npx techradar migrate
+```
+
+It is **read-only** — nothing is rewritten. The output lists every legacy key
+it finds in `config.json`, every `quadrant:` frontmatter still in `radar/`, and
+every theme manifest still on the v1 `colorScheme` shape, with a one-line
+pointer per finding into the section of this document that explains the fix.
+Exit code is `0` when the project is v2-clean and `1` otherwise, so the same
+command doubles as a CI gate during your migration.
+
+The setup step that runs before `npx techradar dev` / `build` / `validate` /
+`serve` also prints a one-line nudge if it spots any of these errors in your
+project, so you do not need to remember to run `migrate` by hand.
+
+#### Apply the safe mechanical rewrites: `npx techradar migrate --apply`
+
+Once you've reviewed the report, re-run with `--apply` to perform the two
+deterministic rewrites that need no input from you:
+
+```bash
+npx techradar migrate --apply
+```
+
+This renames `quadrants` → `segments` in `config.json` (preserving key order)
+and `quadrant:` → `segment:` in the YAML frontmatter of every file under
+`radar/` (Markdown bodies are never touched). Before any write, every modified
+file is mirrored into `.techradar-migrate-backup/<timestamp>/` so you can diff
+or restore. Add that path to `.gitignore` or commit the snapshot — your call.
+
+`--apply` does **not** touch the v2-incompatible color and theme keys (Section
+3 below). Those need to land in a `themes/<id>/manifest.jsonc` you author
+by hand, and the detector reports them as remaining work after `--apply` runs.
+
+#### Auto-generate the theme manifest: `npx techradar migrate --extract-theme`
+
+To skip the hand-authoring of Section 3, run:
+
+```bash
+npx techradar migrate --extract-theme
+```
+
+You will be prompted for a theme id, label, supported modes (`light`, `dark`,
+or both), and the default mode (when both are supported). The command then
+reads the legacy `colors`, `backgroundImage`, `backgroundOpacity`,
+`segments[].color`, and `rings[].color` from `config.json`, writes a complete
+`themes/<id>/manifest.jsonc`, copies the background asset alongside it,
+strips those keys from `config.json`, and inserts `"defaultTheme": "<id>"`.
+All modified files are mirrored into `.techradar-migrate-backup/<timestamp>/`
+first, exactly like `--apply`.
+
+Non-interactive flags: `--theme-id`, `--theme-label`, `--theme-supports`
+(comma-separated, e.g. `light,dark`), `--theme-default`. Useful for CI or
+scripted migrations.
+
+Any v1 color key that has no v2 equivalent is reported as `unmappedColors` —
+the manifest is still written, and you decide whether to drop those keys or
+add `cssVariables` overrides by hand.
+
+### What you get for free
+
+- `quadrants` in `config.json` and `quadrant:` in frontmatter still work, but
+  emit a `[deprecated]` warning at build time. Both shims are scheduled for
+  removal in v3 — fix them now, while the warnings make them easy to find.
+
+### What will break the build until you fix it
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `config.json: 'colors' is no longer supported in v2.x.x.` | Root `colors` block in `config.json` | Move into `themes/<id>/manifest.jsonc` (Section 3). |
+| `config.json: 'backgroundImage' is no longer supported in v2.x.x.` | Root `backgroundImage` in `config.json` | Move into `themes/<id>/manifest.jsonc` `background.image` (Section 3). |
+| `config.json: 'backgroundOpacity' is no longer supported in v2.x.x.` | Root `backgroundOpacity` in `config.json` | Move into `themes/<id>/manifest.jsonc` `background.opacity` (Section 3). |
+| `config.json: 'segments[].color' is no longer supported in v2.x.x.` | `color:` field on any segment object | Move into `radar.segments[]` of your theme manifest (Section 3). |
+| `config.json: 'rings[].color' is no longer supported in v2.x.x.` | `color:` field on any ring object | Move into `radar.rings[]` of your theme manifest (Section 3). |
+| `config.json: 'defaultTheme' is required and must be a non-empty string …` | New required field | Add `"defaultTheme": "<id>"` (Section 1). |
+| `Theme '<id>' uses the legacy v1 schema (colorScheme field).` | An existing custom theme uses v1's flat `colorScheme` shape | Rewrite `manifest.jsonc` against `themes/.example/manifest.jsonc` (Section 3). |
+
+---
+
+### 1. Decide on a theme id, then add `defaultTheme` to `config.json`
+
+`defaultTheme` is now required. Pick a short, lowercase id for the theme
+you're about to author — typically your organization name.
+
+```diff
+ {
+   "basePath": "/techradar",
+   "baseUrl": "https://techradar.acme.io",
++  "defaultTheme": "acme",
+   ...
+ }
+```
+
+If you only want to use one of the seven shipped themes (`blueprint`,
+`matrix`, `neutral`, `porsche`, `porsche-heritage`, `solarized`, `synthwave`),
+use that id and skip Section 3 entirely.
+
+You can optionally pin the initial mode with `:light` or `:dark`:
+
+```jsonc
+"defaultTheme": "acme:dark"
+```
+
+When omitted, dual-mode themes start in `system` mode and single-mode themes
+use the only mode they support. The user can override at runtime; the choice
+is persisted to `localStorage`.
+
+---
+
+### 2. Rename `quadrants` → `segments` (mechanical)
+
+Two places need this rename. Both are no-ops in behavior — only the key
+name changed.
+
+#### 2a. `config.json`
+
+```diff
+ {
+-  "quadrants": [
++  "segments": [
+     { "id": "languages-and-frameworks", "title": "Languages & Frameworks" },
+     ...
+   ]
+ }
+```
+
+#### 2b. Every `radar/<release>/<id>.md` file
+
+```diff
+ ---
+ title: "React"
+ ring: adopt
+-quadrant: languages-and-frameworks
++segment: languages-and-frameworks
+ ---
+```
+
+A one-shot rewrite for the markdown files (run from your project root, dry-
+run with `--dry-run` first if your `sd` version supports it):
+
+```bash
+# Using sd (https://github.com/chmln/sd)
+find radar -name '*.md' -print0 | xargs -0 sd '^quadrant:' 'segment:'
+```
+
+Or with `sed` on macOS / BSD:
+
+```bash
+find radar -name '*.md' -exec sed -i '' 's/^quadrant:/segment:/' {} +
+```
+
+After the rename, `pnpm run validate` (or `npx techradar validate`) should be
+silent — no more `[deprecated] frontmatter key "quadrant" …` warnings.
+
+---
+
+### 3. Move colors out of `config.json` and into a theme manifest
+
+This is the only step that requires authoring rather than mechanical
+rewrites.
+
+#### 3a. Create the theme folder
+
+Copy the annotated example into a folder named after the id you picked in
+Section 1:
+
+```bash
+mkdir -p themes/acme
+cp node_modules/@porscheofficial/porschedigital-technology-radar/data/themes/.example/manifest.jsonc themes/acme/
+```
+
+Or, if you already ran `npx techradar init` against v2, the `.example` folder
+is also discoverable under your local `themes/`. The leading dot makes
+it hidden from the theme scanner — **your copy must NOT start with a dot**.
+
+#### 3b. Map your v1 keys into the new manifest
+
+This is the full mapping. Anything on the right is required unless marked
+*(optional)*; anything not in your v1 file gets a sensible default — the
+template comments tell you what each field is for.
+
+| v1 `config.json` field | v2 location in `manifest.jsonc` |
+|---|---|
+| `colors.foreground` | `cssVariables.foreground` |
+| `colors.background` | `cssVariables.background` |
+| `colors.highlight` | `cssVariables.highlight` |
+| `colors.content` | `cssVariables.content` |
+| `colors.text` | `cssVariables.text` |
+| `colors.link` | `cssVariables.link` |
+| `colors.border` | `cssVariables.border` |
+| `colors.tag` | `cssVariables.tag` |
+| `backgroundImage` *(optional)* | `background.image` (and copy the file into the theme folder) |
+| `backgroundOpacity` *(optional)* | `background.opacity` |
+| `segments[].color` (in declaration order) | `radar.segments[]` (same order) |
+| `rings[].color` (in declaration order) | `radar.rings[]` (same order) |
+
+Four `cssVariables` keys did not exist in v1 and must be filled in:
+
+| New key | What it controls | Quick default |
+|---|---|---|
+| `surface` | Card / panel background sitting on top of `background` | `#FFFFFF` for light, one tier lighter than `background` for dark |
+| `footer` | Footer-strip background | Same as `surface` (or a darker band) |
+| `shading` | Modal / overlay scrim | `rgba(20, 20, 20, 0.2)` light, `rgba(20, 20, 20, 0.67)` dark |
+| `frosted` | Backdrop blur tint behind sticky header | `rgba(255, 255, 255, 0.5)` light, `rgba(40, 40, 40, 0.35)` dark |
+
+If you're unsure, copy the values from `themes/neutral/manifest.jsonc`
+— it's the safest baseline.
+
+#### 3c. Pick `supports` and `default`
+
+```jsonc
+"supports": ["light", "dark"],   // 1–2 entries from {"light","dark"}
+"default":  "dark"               // must appear in supports
+```
+
+If your v1 site only had a single palette, the simplest path is to declare
+`supports: ["dark"]` (or `["light"]`) and use single-string values
+everywhere instead of `{ "light": …, "dark": … }` objects.
+
+If you want both modes, you have two options:
+
+1. **Quick**: duplicate your v1 palette into both modes (visually identical,
+   tweak later).
+2. **Better**: copy the dark palette from a built-in theme like `porsche` or
+   `synthwave` and use your v1 colors as the light palette.
+
+#### 3d. Strip the migrated keys from `config.json`
+
+After the manifest is in place, remove every key the harness rejected:
+
+```diff
+ {
+-  "backgroundImage": "/images/bg-pattern.png",
+-  "backgroundOpacity": 0.04,
+-  "colors": {
+-    "foreground": "#F0F0F5",
+-    "background": "#1A1A2E",
+-    ...
+-  },
+   "segments": [
+     {
+       "id": "languages-and-frameworks",
+       "title": "Languages & Frameworks",
+-      "description": "...",
+-      "color": "#0F9D58"
++      "description": "..."
+     },
+     ...
+   ],
+   "rings": [
+     {
+       "id": "adopt",
+       "title": "Adopt",
+-      "description": "...",
+-      "color": "#0F9D58",
++      "description": "...",
+       "radius": 0.5,
+       "strokeWidth": 5
+     },
+     ...
+   ]
+ }
+```
+
+`segments[]` and `rings[]` keep `id`, `title`, `description`, `radius`, and
+`strokeWidth` — they lose only the `color` field.
+
+---
+
+### 4. Verify
+
+```bash
+npx techradar validate     # frontmatter shimmed warnings disappear
+npx techradar build        # config + theme schema both pass
+```
+
+If the build still throws, the error message tells you exactly which key /
+field is at fault — re-check the table in the "What will break the build"
+section above.
+
+For custom themes that lived under `data/themes/` in a v1 fork (using the
+flat `colorScheme` shape), there is no automated migration — rewrite each
+`manifest.jsonc` against `themes/.example/manifest.jsonc`.
+
+### 5. Custom theme assets
+
+Background images and logos live alongside the manifest:
+
+```
+themes/acme/
+├── manifest.jsonc
+├── background-dark.jpg          ← referenced by background.image.dark
+├── logo-header-light.svg        ← referenced by headerLogoFile.light
+├── logo-header-dark.svg
+└── logo-footer.svg
+```
+
+Asset paths in the manifest are bare filenames (no leading slash, no
+`/themes/...` prefix). The build copies each referenced file into
+`public/themes/<id>/` automatically.
+
+---
+
+## Earlier versions
+
+There is no automated migration tool from pre-v1 forks. Open an issue if you
+need help upgrading from a much older release.

--- a/packages/techradar/README.md
+++ b/packages/techradar/README.md
@@ -5,7 +5,7 @@ A static site generator for building and publishing your own technology radar. D
 [![npm version](https://img.shields.io/npm/v/@porscheofficial/porschedigital-technology-radar?logo=npm)](https://www.npmjs.com/package/@porscheofficial/porschedigital-technology-radar)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/porscheofficial/porschedigital-technology-radar/blob/main/LICENSE)
 
-**[Live showcase](https://opensource.porsche.com/porschedigital-technology-radar/)** · **[Project overview & quickstart](https://github.com/porscheofficial/porschedigital-technology-radar#readme)**
+**[Live showcase](https://opensource.porsche.com/porschedigital-technology-radar/)** · **[Project overview & quickstart](https://github.com/porscheofficial/porschedigital-technology-radar#readme)** · **[Upgrading from v1](./MIGRATION.md)**
 
 ![Screenshot of the Technology Radar](https://raw.githubusercontent.com/porscheofficial/porschedigital-technology-radar/main/docs/assets/screenshot-radar.png)
 
@@ -69,7 +69,8 @@ npx techradar init
 
 Edit the scaffolded files to match your organization:
 
-- `config.json` — branding, segments, rings, colors (see [Configuration](#️-configuration))
+- `config.json` — branding, segments, rings, theme selection (see [Configuration](#️-configuration))
+- `themes/<id>/manifest.jsonc` — colors, palettes, optional logos & background (see [Themes](#themes))
 - `radar/` — your technology items as Markdown (see [Radar Items](#-radar-items))
 - `about.md` — content for the help & about page
 - `public/` — favicon, images, background image
@@ -245,8 +246,19 @@ package are scaffolded there on `npx techradar init`.
 - Mode selection is persisted in `localStorage` under `techradar-mode`.
 - Theme selection is persisted in `localStorage` under `techradar-theme`.
 
-There is no migration CLI for the old flat `colorScheme` schema. Rewrite legacy
-`manifest.jsonc` files by hand using `themes/.example/`.
+Upgrading a v1 consumer project? Run `npx techradar migrate` for a read-only
+diagnostic that lists every legacy key it finds (`config.json`, frontmatter,
+theme manifests) and points each one at the matching fix. Re-run with
+`npx techradar migrate --apply` to perform the safe mechanical rewrites
+(`quadrants` → `segments` in `config.json`, `quadrant:` → `segment:` in
+frontmatter); modified files are first mirrored into
+`.techradar-migrate-backup/<timestamp>/`. Run
+`npx techradar migrate --extract-theme` to interactively generate a theme
+manifest from your legacy `colors` / `backgroundImage` / `segments[].color` /
+`rings[].color` keys (strips them from `config.json` and inserts
+`defaultTheme` for you). See [`MIGRATION.md`](./MIGRATION.md)
+for the full v1 → v2 recipe (the `colorScheme` rewrite itself is manual; use
+`themes/.example/manifest.jsonc` as the template).
 
 #### Theme assets
 
@@ -284,8 +296,7 @@ time.
   "basePath": "/techradar",
   "baseUrl": "https://techradar.acme.io",
   "editUrl": "https://github.dev/acme/techradar/blob/main/radar/{release}/{id}.md",
-  "backgroundImage": "/images/bg-pattern.png",
-  "backgroundOpacity": 0.04,
+  "defaultTheme": "acme",
   "imprint": "https://acme.io/legal",
   "toggles": {
     "showSearch": true,
@@ -295,40 +306,26 @@ time.
     "showBlipChange": true,
     "multiSelectFilters": true
   },
-  "colors": {
-    "foreground": "#F0F0F5",
-    "background": "#1A1A2E",
-    "highlight": "#E94560",
-    "content": "#A0A0B0",
-    "text": "#707080",
-    "link": "#E94560",
-    "border": "#2A2A40",
-    "tag": "#2A2A40"
-  },
   "segments": [
     {
       "id": "languages-and-frameworks",
       "title": "Languages & Frameworks",
-      "description": "Programming languages and application frameworks used across our stack.",
-      "color": "#0F9D58"
+      "description": "Programming languages and application frameworks used across our stack."
     },
     {
       "id": "infrastructure",
       "title": "Infrastructure",
-      "description": "Cloud platforms, orchestration, and infrastructure-as-code tools.",
-      "color": "#4285F4"
+      "description": "Cloud platforms, orchestration, and infrastructure-as-code tools."
     },
     {
       "id": "data-and-ai",
       "title": "Data & AI",
-      "description": "Data pipelines, storage, analytics, and machine learning frameworks.",
-      "color": "#F4B400"
+      "description": "Data pipelines, storage, analytics, and machine learning frameworks."
     },
     {
       "id": "developer-experience",
       "title": "Developer Experience",
-      "description": "Tools and practices that improve developer productivity and satisfaction.",
-      "color": "#DB4437"
+      "description": "Tools and practices that improve developer productivity and satisfaction."
     }
   ],
   "rings": [
@@ -336,7 +333,6 @@ time.
       "id": "adopt",
       "title": "Adopt",
       "description": "Proven in production. Use by default for new projects.",
-      "color": "#0F9D58",
       "radius": 0.5,
       "strokeWidth": 5
     },
@@ -344,7 +340,6 @@ time.
       "id": "trial",
       "title": "Trial",
       "description": "Worth pursuing. Use in non-critical projects to build experience.",
-      "color": "#4285F4",
       "radius": 0.69,
       "strokeWidth": 3
     },
@@ -352,7 +347,6 @@ time.
       "id": "assess",
       "title": "Assess",
       "description": "Interesting. Explore in spikes or proof-of-concepts.",
-      "color": "#F4B400",
       "radius": 0.85,
       "strokeWidth": 2
     },
@@ -360,7 +354,6 @@ time.
       "id": "hold",
       "title": "Hold",
       "description": "Do not start new work with this. Migrate away when practical.",
-      "color": "#DB4437",
       "radius": 1,
       "strokeWidth": 0.75
     }

--- a/packages/techradar/bin/__tests__/migrateApply.test.ts
+++ b/packages/techradar/bin/__tests__/migrateApply.test.ts
@@ -1,0 +1,251 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyMechanicalRenames } from "../migrateApply";
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function writeText(filePath: string, contents: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents, "utf-8");
+}
+
+describe("migrateApply", () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(path.join(tmpdir(), "techradar-apply-"));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  describe("config.json rename", () => {
+    it("renames quadrants → segments and preserves key order", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        title: "My Radar",
+        defaultTheme: "porsche",
+        quadrants: [{ id: "tools", name: "Tools" }],
+        rings: [{ id: "adopt", name: "Adopt" }],
+        labels: { footer: "x" },
+      });
+
+      const result = applyMechanicalRenames({ cwd });
+
+      expect(result.changes.map((c) => c.file)).toContain("config.json");
+      expect(result.errors).toEqual([]);
+      const after = JSON.parse(
+        readFileSync(path.join(cwd, "config.json"), "utf-8"),
+      );
+      expect(after).not.toHaveProperty("quadrants");
+      expect(after.segments).toEqual([{ id: "tools", name: "Tools" }]);
+      expect(Object.keys(after)).toEqual([
+        "title",
+        "defaultTheme",
+        "segments",
+        "rings",
+        "labels",
+      ]);
+    });
+
+    it("does nothing when config.json is missing", () => {
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.changes).toEqual([]);
+      expect(result.backupDir).toBeNull();
+    });
+
+    it("skips when both quadrants and segments coexist (ambiguous)", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        quadrants: [{ id: "old" }],
+        segments: [{ id: "new" }],
+      });
+
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.changes.map((c) => c.file)).not.toContain("config.json");
+      const after = JSON.parse(
+        readFileSync(path.join(cwd, "config.json"), "utf-8"),
+      );
+      expect(after).toHaveProperty("quadrants");
+      expect(after).toHaveProperty("segments");
+    });
+
+    it("skips when config.json is unparseable (detector reports it)", () => {
+      writeText(path.join(cwd, "config.json"), "{ not: json,");
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.changes).toEqual([]);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("does not rename when only segments is present (already v2)", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        segments: [{ id: "tools" }],
+      });
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.changes).toEqual([]);
+    });
+  });
+
+  describe("frontmatter rename", () => {
+    it("renames quadrant: → segment: in frontmatter only", () => {
+      const md = path.join(cwd, "radar", "2024-01", "blip.md");
+      writeText(
+        md,
+        "---\ntitle: Foo\nring: adopt\nquadrant: tools\n---\n\nBody mentioning quadrant: should not change.\n",
+      );
+
+      const result = applyMechanicalRenames({ cwd });
+
+      expect(result.errors).toEqual([]);
+      expect(result.changes.map((c) => c.file)).toContain(
+        path.join("radar", "2024-01", "blip.md"),
+      );
+      const after = readFileSync(md, "utf-8");
+      expect(after).toContain("segment: tools");
+      expect(after).not.toMatch(/^quadrant:/m);
+      expect(after).toContain("Body mentioning quadrant: should not change.");
+    });
+
+    it("walks subdirectories recursively", () => {
+      const a = path.join(cwd, "radar", "a", "x.md");
+      const b = path.join(cwd, "radar", "b", "y.md");
+      writeText(a, "---\nquadrant: tools\nring: adopt\n---\nA\n");
+      writeText(b, "---\nquadrant: data\nring: trial\n---\nB\n");
+
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.changes).toHaveLength(2);
+      expect(readFileSync(a, "utf-8")).toContain("segment: tools");
+      expect(readFileSync(b, "utf-8")).toContain("segment: data");
+    });
+
+    it("skips files that already have segment: alongside quadrant:", () => {
+      const md = path.join(cwd, "radar", "blip.md");
+      writeText(
+        md,
+        "---\nquadrant: old\nsegment: new\nring: adopt\n---\nBody\n",
+      );
+
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.changes).toEqual([]);
+      expect(readFileSync(md, "utf-8")).toContain("quadrant: old");
+    });
+
+    it("skips files without a frontmatter fence", () => {
+      const md = path.join(cwd, "radar", "no-fm.md");
+      writeText(md, "# heading only, quadrant: nope\n");
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.changes).toEqual([]);
+    });
+
+    it("does nothing when radar/ is missing", () => {
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.changes).toEqual([]);
+    });
+  });
+
+  describe("backup", () => {
+    it("snapshots every modified file under .techradar-migrate-backup/<ts>/", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        quadrants: [{ id: "tools" }],
+      });
+      const md = path.join(cwd, "radar", "2024-01", "blip.md");
+      writeText(md, "---\nquadrant: tools\nring: adopt\n---\nBody\n");
+
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.backupDir).not.toBeNull();
+      const backupAbs = path.join(cwd, result.backupDir as string);
+      expect(existsSync(path.join(backupAbs, "config.json"))).toBe(true);
+      expect(
+        existsSync(path.join(backupAbs, "radar", "2024-01", "blip.md")),
+      ).toBe(true);
+
+      const restoredConfig = JSON.parse(
+        readFileSync(path.join(backupAbs, "config.json"), "utf-8"),
+      );
+      expect(restoredConfig).toHaveProperty("quadrants");
+      expect(restoredConfig).not.toHaveProperty("segments");
+
+      const restoredMd = readFileSync(
+        path.join(backupAbs, "radar", "2024-01", "blip.md"),
+        "utf-8",
+      );
+      expect(restoredMd).toContain("quadrant: tools");
+    });
+
+    it("does not create a backup directory when there is nothing to change", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        segments: [{ id: "tools" }],
+      });
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.backupDir).toBeNull();
+      expect(existsSync(path.join(cwd, ".techradar-migrate-backup"))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("dry-run (write: false)", () => {
+    it("returns ChangeRecords without writing or backing up", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        quadrants: [{ id: "tools" }],
+      });
+      const md = path.join(cwd, "radar", "blip.md");
+      writeText(md, "---\nquadrant: tools\nring: adopt\n---\nBody\n");
+
+      const result = applyMechanicalRenames({ cwd, write: false });
+      expect(result.changes).toHaveLength(2);
+      expect(result.backupDir).toBeNull();
+
+      const cfg = JSON.parse(
+        readFileSync(path.join(cwd, "config.json"), "utf-8"),
+      );
+      expect(cfg).toHaveProperty("quadrants");
+      expect(cfg).not.toHaveProperty("segments");
+      expect(readFileSync(md, "utf-8")).toContain("quadrant: tools");
+      expect(existsSync(path.join(cwd, ".techradar-migrate-backup"))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("orchestrator combined", () => {
+    it("applies config + frontmatter changes and reports all of them", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        quadrants: [{ id: "tools" }],
+      });
+      const md1 = path.join(cwd, "radar", "a.md");
+      const md2 = path.join(cwd, "radar", "sub", "b.md");
+      writeText(md1, "---\nquadrant: tools\nring: adopt\n---\nA\n");
+      writeText(md2, "---\nquadrant: data\nring: trial\n---\nB\n");
+
+      const result = applyMechanicalRenames({ cwd });
+      expect(result.changes).toHaveLength(3);
+      expect(result.errors).toEqual([]);
+      expect(result.backupDir).not.toBeNull();
+
+      const backupContents = readdirSync(
+        path.join(cwd, result.backupDir as string),
+      );
+      expect(backupContents).toContain("config.json");
+      expect(backupContents).toContain("radar");
+    });
+  });
+});

--- a/packages/techradar/bin/__tests__/migrateDetect.test.ts
+++ b/packages/techradar/bin/__tests__/migrateDetect.test.ts
@@ -1,0 +1,284 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  detectAll,
+  detectConfigJson,
+  detectFrontmatter,
+  detectThemes,
+  type Finding,
+} from "../migrateDetect";
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function writeText(filePath: string, contents: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents, "utf-8");
+}
+
+function keys(findings: Finding[]): string[] {
+  return findings.map((f) => f.key);
+}
+
+describe("migrateDetect", () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(path.join(tmpdir(), "techradar-migrate-"));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  describe("detectConfigJson", () => {
+    it("returns no findings when config.json is missing", () => {
+      expect(detectConfigJson(cwd)).toEqual([]);
+    });
+
+    it("returns no findings on a valid v2 config", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        segments: [{ id: "platforms" }, { id: "languages" }],
+        rings: [{ id: "adopt" }, { id: "trial" }],
+      });
+      expect(detectConfigJson(cwd)).toEqual([]);
+    });
+
+    it("flags every legacy root key as error", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        segments: [],
+        rings: [],
+        colors: { foreground: "#000" },
+        backgroundImage: "bg.png",
+        backgroundOpacity: 0.5,
+      });
+      const found = detectConfigJson(cwd);
+      expect(keys(found)).toEqual(
+        expect.arrayContaining([
+          "config.json:colors",
+          "config.json:backgroundImage",
+          "config.json:backgroundOpacity",
+        ]),
+      );
+      for (const key of [
+        "config.json:colors",
+        "config.json:backgroundImage",
+        "config.json:backgroundOpacity",
+      ]) {
+        const f = found.find((x) => x.key === key);
+        expect(f?.severity).toBe("error");
+      }
+    });
+
+    it("warns (not errors) on quadrants without segments", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        quadrants: [{ id: "platforms" }],
+        rings: [],
+      });
+      const found = detectConfigJson(cwd);
+      const quadrantsFinding = found.find(
+        (f) => f.key === "config.json:quadrants",
+      );
+      expect(quadrantsFinding?.severity).toBe("warn");
+    });
+
+    it("does not warn on quadrants when segments is also present", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        quadrants: [{ id: "old" }],
+        segments: [{ id: "new" }],
+        rings: [],
+      });
+      const found = detectConfigJson(cwd);
+      expect(keys(found)).not.toContain("config.json:quadrants");
+    });
+
+    it("flags per-segment colors (under both segments and quadrants alias)", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        quadrants: [{ id: "a", color: "#fff" }, { id: "b" }],
+        rings: [],
+      });
+      const found = detectConfigJson(cwd);
+      expect(keys(found)).toContain("config.json:segments[0].color");
+      expect(keys(found)).not.toContain("config.json:segments[1].color");
+    });
+
+    it("flags per-ring colors", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        segments: [],
+        rings: [{ id: "adopt", color: "#0f0" }],
+      });
+      const found = detectConfigJson(cwd);
+      expect(keys(found)).toContain("config.json:rings[0].color");
+    });
+
+    it("flags missing defaultTheme as error", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        segments: [],
+        rings: [],
+      });
+      const found = detectConfigJson(cwd);
+      const f = found.find((x) => x.key === "config.json:defaultTheme");
+      expect(f?.severity).toBe("error");
+    });
+
+    it("flags empty defaultTheme as error", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "   ",
+        segments: [],
+        rings: [],
+      });
+      const found = detectConfigJson(cwd);
+      expect(keys(found)).toContain("config.json:defaultTheme");
+    });
+
+    it("returns a single parse-error finding on broken JSON (does not throw)", () => {
+      writeText(path.join(cwd, "config.json"), "{ not json");
+      const found = detectConfigJson(cwd);
+      expect(found).toHaveLength(1);
+      expect(found[0]?.key).toBe("config.json:parse");
+      expect(found[0]?.severity).toBe("error");
+    });
+  });
+
+  describe("detectFrontmatter", () => {
+    it("returns no findings when radar/ is missing", () => {
+      expect(detectFrontmatter(cwd)).toEqual([]);
+    });
+
+    it("warns once per file using legacy quadrant key", () => {
+      writeText(
+        path.join(cwd, "radar", "2024-01-01", "alpha.md"),
+        "---\ntitle: Alpha\nring: adopt\nquadrant: platforms\n---\nbody\n",
+      );
+      writeText(
+        path.join(cwd, "radar", "2024-01-01", "beta.md"),
+        "---\ntitle: Beta\nring: adopt\nsegment: platforms\n---\nbody\n",
+      );
+      const found = detectFrontmatter(cwd);
+      expect(found).toHaveLength(1);
+      expect(found[0]?.severity).toBe("warn");
+      expect(found[0]?.file).toContain("alpha.md");
+    });
+
+    it("does not warn when both quadrant and segment are present (segment wins)", () => {
+      writeText(
+        path.join(cwd, "radar", "x.md"),
+        "---\nring: adopt\nquadrant: a\nsegment: a\n---\n",
+      );
+      expect(detectFrontmatter(cwd)).toEqual([]);
+    });
+
+    it("recurses into nested radar subdirectories", () => {
+      writeText(
+        path.join(cwd, "radar", "2024", "Q1", "deep.md"),
+        "---\nring: adopt\nquadrant: a\n---\n",
+      );
+      const found = detectFrontmatter(cwd);
+      expect(found).toHaveLength(1);
+      expect(found[0]?.file).toContain(path.join("radar", "2024", "Q1"));
+    });
+  });
+
+  describe("detectThemes", () => {
+    it("returns no findings when themes/ is missing", () => {
+      expect(detectThemes(cwd)).toEqual([]);
+    });
+
+    it("flags themes with legacy colorScheme as error", () => {
+      writeText(
+        path.join(cwd, "themes", "legacy", "manifest.jsonc"),
+        '{\n  "label": "Legacy",\n  "colorScheme": { "foreground": "#000" }\n}\n',
+      );
+      const found = detectThemes(cwd);
+      expect(found).toHaveLength(1);
+      expect(found[0]?.severity).toBe("error");
+      expect(found[0]?.key).toContain(":colorScheme");
+    });
+
+    it("ignores dot-prefixed theme dirs (.example)", () => {
+      writeText(
+        path.join(cwd, "themes", ".example", "manifest.jsonc"),
+        '{ "colorScheme": { } }\n',
+      );
+      expect(detectThemes(cwd)).toEqual([]);
+    });
+
+    it("returns no findings for a valid v2 manifest", () => {
+      writeText(
+        path.join(cwd, "themes", "neo", "manifest.jsonc"),
+        '{\n  // v2 shape — trailing comma allowed\n  "label": "Neo",\n  "supports": ["light"],\n  "default": "light",\n}\n',
+      );
+      expect(detectThemes(cwd)).toEqual([]);
+    });
+
+    it("emits a parse-error finding for malformed JSONC (does not throw)", () => {
+      writeText(
+        path.join(cwd, "themes", "broken", "manifest.jsonc"),
+        "{ not valid",
+      );
+      const found = detectThemes(cwd);
+      expect(found).toHaveLength(1);
+      expect(found[0]?.severity).toBe("error");
+      expect(found[0]?.key).toContain(":parse");
+    });
+  });
+
+  describe("detectAll", () => {
+    it("reports clean on a valid v2 project", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        segments: [{ id: "a" }],
+        rings: [{ id: "adopt" }],
+      });
+      const report = detectAll(cwd);
+      expect(report.findings).toEqual([]);
+      expect(report.hasV1Markers).toBe(false);
+      expect(report.hasErrors).toBe(false);
+    });
+
+    it("aggregates findings across all three scanners", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        quadrants: [{ id: "a", color: "#fff" }],
+        rings: [{ id: "adopt", color: "#0f0" }],
+        colors: {},
+      });
+      writeText(
+        path.join(cwd, "radar", "x.md"),
+        "---\nring: adopt\nquadrant: a\n---\n",
+      );
+      writeText(
+        path.join(cwd, "themes", "legacy", "manifest.jsonc"),
+        '{ "colorScheme": {} }\n',
+      );
+      const report = detectAll(cwd);
+      expect(report.hasErrors).toBe(true);
+      expect(report.hasV1Markers).toBe(true);
+      expect(report.findings.some((f) => f.file === "config.json")).toBe(true);
+      expect(report.findings.some((f) => f.file.endsWith("x.md"))).toBe(true);
+      expect(
+        report.findings.some((f) => f.file.includes("manifest.jsonc")),
+      ).toBe(true);
+    });
+
+    it("hasErrors is false when only soft warns are present", () => {
+      writeJson(path.join(cwd, "config.json"), {
+        defaultTheme: "porsche",
+        quadrants: [{ id: "a" }],
+        rings: [{ id: "adopt" }],
+      });
+      const report = detectAll(cwd);
+      expect(report.hasV1Markers).toBe(true);
+      expect(report.hasErrors).toBe(false);
+    });
+  });
+});

--- a/packages/techradar/bin/__tests__/migrateThemes.test.ts
+++ b/packages/techradar/bin/__tests__/migrateThemes.test.ts
@@ -1,0 +1,393 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parse as parseJsonc } from "jsonc-parser";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extractThemeFromConfig, type ThemeMode } from "../migrateThemes";
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function writeBytes(filePath: string, contents: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents, "utf-8");
+}
+
+const V1_FULL_CONFIG = {
+  $schema: "./schema.json",
+  title: "Acme",
+  colors: {
+    foreground: "#000000",
+    background: "#FFFFFF",
+    highlight: "#FF0000",
+    content: "#222222",
+    text: "#333333",
+    link: "#0000EE",
+    border: "#CCCCCC",
+    tag: "#EEEEEE",
+  },
+  backgroundImage: "/bg.jpg",
+  backgroundOpacity: 0.5,
+  segments: [
+    { id: "platforms", name: "Platforms", color: "#AA0000" },
+    { id: "tools", name: "Tools", color: "#00AA00" },
+  ],
+  rings: [
+    { id: "adopt", name: "Adopt", color: "#0000AA" },
+    { id: "trial", name: "Trial", color: "#0000BB" },
+    { id: "assess", name: "Assess", color: "#0000CC" },
+    { id: "hold", name: "Hold", color: "#0000DD" },
+  ],
+};
+
+function readManifest(cwd: string, themeId: string): Record<string, unknown> {
+  const text = readFileSync(
+    path.join(cwd, "themes", themeId, "manifest.jsonc"),
+    "utf8",
+  );
+  return parseJsonc(text) as Record<string, unknown>;
+}
+
+function readConfig(cwd: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(path.join(cwd, "config.json"), "utf8"),
+  ) as Record<string, unknown>;
+}
+
+describe("migrateThemes", () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(path.join(tmpdir(), "techradar-themes-"));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  describe("input validation", () => {
+    it("errors when defaultMode is not in supports", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "dark",
+      });
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].file).toBe("(input)");
+      expect(result.changes).toHaveLength(0);
+      expect(result.backupDir).toBeNull();
+    });
+
+    it("errors when config.json is missing", () => {
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].file).toBe("config.json");
+      expect(result.errors[0].message).toMatch(/not found/);
+    });
+
+    it("errors when config.json is unparseable", () => {
+      writeBytes(path.join(cwd, "config.json"), "{ not valid json");
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].file).toBe("config.json");
+    });
+  });
+
+  describe("manifest extraction (single mode)", () => {
+    it("maps all 8 v1 color keys + fills 4 v2-only defaults", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      expect(result.errors).toHaveLength(0);
+      const manifest = readManifest(cwd, "acme");
+      expect(manifest.label).toBe("Acme");
+      expect(manifest.supports).toEqual(["light"]);
+      expect(manifest.default).toBe("light");
+      const css = manifest.cssVariables as Record<string, unknown>;
+      expect(Object.keys(css).sort()).toEqual(
+        [
+          "background",
+          "border",
+          "content",
+          "footer",
+          "foreground",
+          "frosted",
+          "highlight",
+          "link",
+          "shading",
+          "surface",
+          "tag",
+          "text",
+        ].sort(),
+      );
+      expect(css.foreground).toBe("#000000");
+      expect(css.tag).toBe("#EEEEEE");
+      expect(typeof css.surface).toBe("string");
+    });
+
+    it("maps segments[].color and rings[].color into radar palette", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      const manifest = readManifest(cwd, "acme");
+      const radar = manifest.radar as Record<string, unknown>;
+      expect(radar.segments).toEqual(["#AA0000", "#00AA00"]);
+      expect(radar.rings).toEqual(["#0000AA", "#0000BB", "#0000CC", "#0000DD"]);
+    });
+
+    it("resolves segments via quadrants alias when segments key absent", () => {
+      const v1WithQuadrants = {
+        ...V1_FULL_CONFIG,
+        segments: undefined,
+        quadrants: V1_FULL_CONFIG.segments,
+      };
+      writeJson(path.join(cwd, "config.json"), v1WithQuadrants);
+      extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      const manifest = readManifest(cwd, "acme");
+      const radar = manifest.radar as Record<string, unknown>;
+      expect(radar.segments).toEqual(["#AA0000", "#00AA00"]);
+    });
+  });
+
+  describe("manifest extraction (dual mode)", () => {
+    it("wraps every color value into {light, dark} when supports has both", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light", "dark"],
+        defaultMode: "light",
+      });
+      const manifest = readManifest(cwd, "acme");
+      const css = manifest.cssVariables as Record<string, unknown>;
+      expect(css.foreground).toEqual({ light: "#000000", dark: "#000000" });
+      expect(css.surface).toEqual({ light: "#FFFFFF", dark: "#111111" });
+      const radar = manifest.radar as Record<string, unknown>;
+      expect((radar.segments as unknown[])[0]).toEqual({
+        light: "#AA0000",
+        dark: "#AA0000",
+      });
+    });
+  });
+
+  describe("config strip", () => {
+    it("removes legacy root keys, strips per-item color, inserts defaultTheme", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      const config = readConfig(cwd);
+      expect(config.colors).toBeUndefined();
+      expect(config.backgroundImage).toBeUndefined();
+      expect(config.backgroundOpacity).toBeUndefined();
+      expect(config.defaultTheme).toBe("acme");
+      const segments = config.segments as Array<Record<string, unknown>>;
+      expect(segments[0].color).toBeUndefined();
+      expect(segments[0].id).toBe("platforms");
+      const rings = config.rings as Array<Record<string, unknown>>;
+      expect(rings[0].color).toBeUndefined();
+      expect(rings[0].id).toBe("adopt");
+    });
+
+    it("places defaultTheme right after $schema when present", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      const text = readFileSync(path.join(cwd, "config.json"), "utf8");
+      const idxSchema = text.indexOf('"$schema"');
+      const idxDefault = text.indexOf('"defaultTheme"');
+      expect(idxSchema).toBeGreaterThan(-1);
+      expect(idxDefault).toBeGreaterThan(idxSchema);
+      const idxTitle = text.indexOf('"title"');
+      expect(idxDefault).toBeLessThan(idxTitle);
+    });
+  });
+
+  describe("unmapped colors", () => {
+    it("reports v1 colors keys that have no v2 cssVariables equivalent", () => {
+      const cfg = {
+        ...V1_FULL_CONFIG,
+        colors: { ...V1_FULL_CONFIG.colors, accent: "#FF00FF", brand: "#123" },
+      };
+      writeJson(path.join(cwd, "config.json"), cfg);
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      expect(result.unmappedColors.sort()).toEqual(["accent", "brand"]);
+    });
+  });
+
+  describe("asset copy", () => {
+    it("copies background image from public/ into the theme dir", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      writeBytes(path.join(cwd, "public", "bg.jpg"), "FAKEJPG");
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      const expectedDest = path.join("themes", "acme", "bg.jpg");
+      expect(result.changes.some((c) => c.file === expectedDest)).toBe(true);
+      expect(existsSync(path.join(cwd, "themes", "acme", "bg.jpg"))).toBe(true);
+      const manifest = readManifest(cwd, "acme");
+      const bg = manifest.background as Record<string, unknown>;
+      expect(bg.image).toBe("bg.jpg");
+      expect(bg.opacity).toBe(0.5);
+    });
+
+    it("does not include an asset copy when the file is not found", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      const copyChange = result.changes.find((c) => c.file.endsWith("bg.jpg"));
+      expect(copyChange).toBeUndefined();
+    });
+  });
+
+  describe("backup & dry-run", () => {
+    it("snapshots config.json before writing", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      expect(result.backupDir).not.toBeNull();
+      const backupAbs = path.join(cwd, result.backupDir as string);
+      expect(existsSync(path.join(backupAbs, "config.json"))).toBe(true);
+      const backupConfig = JSON.parse(
+        readFileSync(path.join(backupAbs, "config.json"), "utf8"),
+      );
+      expect(backupConfig.colors).toBeDefined();
+      expect(backupConfig.backgroundImage).toBe("/bg.jpg");
+    });
+
+    it("write:false plans changes without backup or writes", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+        write: false,
+      });
+      expect(result.changes.length).toBeGreaterThan(0);
+      expect(result.backupDir).toBeNull();
+      expect(existsSync(path.join(cwd, "themes", "acme"))).toBe(false);
+      const original = readConfig(cwd);
+      expect(original.colors).toBeDefined();
+    });
+  });
+
+  describe("starter manifest (no v1 theming)", () => {
+    it("creates a manifest from defaults when config has no v1 colors", () => {
+      const v2Like = {
+        title: "Acme",
+        segments: [{ id: "a", name: "A" }],
+        rings: [{ id: "adopt", name: "Adopt" }],
+      };
+      writeJson(path.join(cwd, "config.json"), v2Like);
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light"],
+        defaultMode: "light",
+      });
+      expect(result.errors).toHaveLength(0);
+      const manifest = readManifest(cwd, "acme");
+      const css = manifest.cssVariables as Record<string, unknown>;
+      expect(Object.keys(css).length).toBe(12);
+    });
+  });
+
+  describe("orchestrator", () => {
+    it("includes manifest + config + asset in changes when all present", () => {
+      writeJson(path.join(cwd, "config.json"), V1_FULL_CONFIG);
+      writeBytes(path.join(cwd, "public", "bg.jpg"), "FAKE");
+      const result = extractThemeFromConfig({
+        cwd,
+        themeId: "acme",
+        label: "Acme",
+        supports: ["light", "dark"] satisfies ThemeMode[],
+        defaultMode: "light",
+      });
+      expect(result.errors).toHaveLength(0);
+      const files = result.changes.map((c) => c.file);
+      expect(files).toContain(path.join("themes", "acme", "manifest.jsonc"));
+      expect(files).toContain("config.json");
+      expect(files).toContain(path.join("themes", "acme", "bg.jpg"));
+      expect(result.manifestPath).toBe(
+        path.join("themes", "acme", "manifest.jsonc"),
+      );
+      const backupAbs = path.join(cwd, result.backupDir as string);
+      const entries = readdirSync(backupAbs);
+      expect(entries).toContain("config.json");
+    });
+  });
+});

--- a/packages/techradar/bin/migrateApply.ts
+++ b/packages/techradar/bin/migrateApply.ts
@@ -1,0 +1,250 @@
+/**
+ * v1 → v2 mechanical rewrites (Layer 2 of the migration plan).
+ *
+ * Performs only the deterministic renames that need no user input:
+ *   - config.json: top-level `quadrants` → `segments`
+ *   - radar/(slash)(slash)*.md frontmatter: `quadrant:` → `segment:` (YAML fence only)
+ *
+ * Hard-throw v1 keys (root colors, per-segment/ring color, missing
+ * defaultTheme, legacy theme manifests) are intentionally NOT touched here —
+ * those need user choices and are Phase 4 (theme extraction).
+ *
+ * Every write is preceded by a backup snapshot of the affected file under
+ * `.techradar-migrate-backup/<iso-timestamp>/<original-relative-path>`.
+ *
+ * MUST NOT import `src/lib/config.ts` or `scripts/theme/scanner.ts` for the
+ * same reason as migrateDetect.ts: both throw on legacy keys.
+ */
+
+import {
+  copyFileSync,
+  type Dirent,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+export interface ChangeRecord {
+  /** Path relative to cwd. */
+  file: string;
+  /** What was rewritten (one short line, suitable for log output). */
+  description: string;
+}
+
+export interface ApplyError {
+  file: string;
+  message: string;
+}
+
+export interface ApplyResult {
+  changes: ChangeRecord[];
+  /** Backup directory (relative to cwd) or null if no changes were written. */
+  backupDir: string | null;
+  errors: ApplyError[];
+}
+
+export interface ApplyOptions {
+  cwd: string;
+  /**
+   * When false, returns the ChangeRecord list without writing anything (and
+   * without creating a backup). Useful for dry-run previews. Defaults true.
+   */
+  write?: boolean;
+}
+
+const BACKUP_ROOT = ".techradar-migrate-backup";
+
+// ---------------------------------------------------------------------------
+// Backup helper
+// ---------------------------------------------------------------------------
+
+function backupTimestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+}
+
+function snapshotFile(cwd: string, backupDir: string, absPath: string): void {
+  const rel = relative(cwd, absPath);
+  const dest = join(cwd, backupDir, rel);
+  mkdirSync(dirname(dest), { recursive: true });
+  copyFileSync(absPath, dest);
+}
+
+// ---------------------------------------------------------------------------
+// config.json rename
+// ---------------------------------------------------------------------------
+
+interface ConfigRenamePlan {
+  absPath: string;
+  rel: string;
+  before: string;
+  after: string;
+}
+
+function planConfigRename(cwd: string): ConfigRenamePlan | null {
+  const absPath = join(cwd, "config.json");
+  let before: string;
+  try {
+    before = readFileSync(absPath, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(before) as Record<string, unknown>;
+  } catch {
+    return null; // detector already reports parse errors
+  }
+  if (!("quadrants" in parsed) || "segments" in parsed) return null;
+
+  // Object.entries preserves insertion order for string keys, so renaming
+  // in-place this way keeps the user's original key order intact.
+  const renamed = Object.fromEntries(
+    Object.entries(parsed).map(([k, v]) =>
+      k === "quadrants" ? ["segments", v] : [k, v],
+    ),
+  );
+  const after = `${JSON.stringify(renamed, null, 2)}\n`;
+  return { absPath, rel: "config.json", before, after };
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter rename
+// ---------------------------------------------------------------------------
+
+function collectMarkdownFiles(dirPath: string): string[] {
+  const files: string[] = [];
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+/**
+ * Locate the leading `---\n…\n---` YAML fence and rewrite occurrences of
+ * `^quadrant:` to `segment:` inside it. Returns null when no fence is found,
+ * the fence already contains a `segment:` key, or no `quadrant:` key exists.
+ *
+ * The body of the markdown is untouched — only the fenced YAML region is
+ * rewritten. Any leading whitespace before the opening fence is tolerated.
+ */
+function rewriteFrontmatter(content: string): string | null {
+  const fenceMatch = content.match(
+    /^(\s*---\r?\n)([\s\S]*?)(\r?\n---\s*\r?\n)/,
+  );
+  if (!fenceMatch) return null;
+  const [whole, open, yaml, close] = fenceMatch;
+  if (/^segment\s*:/m.test(yaml)) return null;
+  if (!/^quadrant\s*:/m.test(yaml)) return null;
+  const rewritten = yaml.replace(/^quadrant(\s*:)/gm, "segment$1");
+  return content.replace(whole, `${open}${rewritten}${close}`);
+}
+
+interface FrontmatterRenamePlan {
+  absPath: string;
+  rel: string;
+  before: string;
+  after: string;
+}
+
+function planFrontmatterRenames(cwd: string): FrontmatterRenamePlan[] {
+  const radarDir = join(cwd, "radar");
+  try {
+    if (!statSync(radarDir).isDirectory()) return [];
+  } catch {
+    return [];
+  }
+  const plans: FrontmatterRenamePlan[] = [];
+  for (const absPath of collectMarkdownFiles(radarDir)) {
+    let before: string;
+    try {
+      before = readFileSync(absPath, "utf-8");
+    } catch {
+      continue;
+    }
+    const after = rewriteFrontmatter(before);
+    if (after === null || after === before) continue;
+    plans.push({ absPath, rel: relative(cwd, absPath), before, after });
+  }
+  return plans;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export function applyMechanicalRenames(opts: ApplyOptions): ApplyResult {
+  const { cwd, write = true } = opts;
+  const errors: ApplyError[] = [];
+  const changes: ChangeRecord[] = [];
+
+  const configPlan = planConfigRename(cwd);
+  const fmPlans = planFrontmatterRenames(cwd);
+  const totalPlans = (configPlan ? 1 : 0) + fmPlans.length;
+
+  if (totalPlans === 0) {
+    return { changes, backupDir: null, errors };
+  }
+
+  if (!write) {
+    if (configPlan) {
+      changes.push({
+        file: configPlan.rel,
+        description: "Rename top-level 'quadrants' → 'segments'",
+      });
+    }
+    for (const p of fmPlans) {
+      changes.push({
+        file: p.rel,
+        description: "Rename frontmatter 'quadrant:' → 'segment:'",
+      });
+    }
+    return { changes, backupDir: null, errors };
+  }
+
+  const backupDir = join(BACKUP_ROOT, backupTimestamp());
+
+  if (configPlan) {
+    try {
+      snapshotFile(cwd, backupDir, configPlan.absPath);
+      writeFileSync(configPlan.absPath, configPlan.after, "utf-8");
+      changes.push({
+        file: configPlan.rel,
+        description: "Renamed top-level 'quadrants' → 'segments'",
+      });
+    } catch (err) {
+      errors.push({
+        file: configPlan.rel,
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  for (const p of fmPlans) {
+    try {
+      snapshotFile(cwd, backupDir, p.absPath);
+      writeFileSync(p.absPath, p.after, "utf-8");
+      changes.push({
+        file: p.rel,
+        description: "Renamed frontmatter 'quadrant:' → 'segment:'",
+      });
+    } catch (err) {
+      errors.push({ file: p.rel, message: (err as Error).message });
+    }
+  }
+
+  return { changes, backupDir, errors };
+}

--- a/packages/techradar/bin/migrateDetect.ts
+++ b/packages/techradar/bin/migrateDetect.ts
@@ -1,0 +1,304 @@
+/**
+ * v1 → v2 migration detector.
+ *
+ * Read-only scan of a consumer project's CWD that classifies legacy
+ * configuration shapes into actionable findings. Used by:
+ *   - `npx techradar migrate` (this is the whole subcommand)
+ *   - `setup()` in bin/techradar.ts (one-line nudge before hard throws fire)
+ *
+ * MUST NOT import `src/lib/config.ts` or `scripts/theme/scanner.ts` —
+ * both throw on legacy keys, defeating the diagnostic purpose. We do raw
+ * parsing here and never throw; every problem becomes a Finding.
+ *
+ * See MIGRATION.md (Section "v1 → v2") for the user-facing recipe each
+ * finding's `fix` field references.
+ */
+
+import { type Dirent, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import matter from "@11ty/gray-matter";
+import { type ParseError, parse as parseJsonc } from "jsonc-parser";
+
+export type Severity = "error" | "warn";
+
+export interface Finding {
+  /** `error` = v2 hard-throws on this; `warn` = v2 soft-shims with a deprecation warning. */
+  severity: Severity;
+  /** Path relative to scanned cwd. */
+  file: string;
+  /** Stable identifier of the offending key (e.g. `config.json:colors`). */
+  key: string;
+  /** Human-readable description of what's wrong. */
+  message: string;
+  /** Pointer to the MIGRATION.md section that explains the fix. */
+  fix: string;
+}
+
+export interface MigrationReport {
+  findings: Finding[];
+  /** True if any error or warn was found. */
+  hasV1Markers: boolean;
+  /** True if any error (hard-throw) was found. Use for setup() nudge gating. */
+  hasErrors: boolean;
+}
+
+const MIGRATION_DOC = "MIGRATION.md";
+const LEGACY_ROOT_KEYS = [
+  "colors",
+  "backgroundImage",
+  "backgroundOpacity",
+] as const;
+
+// ---------------------------------------------------------------------------
+// config.json
+// ---------------------------------------------------------------------------
+
+function checkLegacyRootKeys(parsed: Record<string, unknown>): Finding[] {
+  const findings: Finding[] = [];
+  for (const key of LEGACY_ROOT_KEYS) {
+    if (key in parsed) {
+      findings.push({
+        severity: "error",
+        file: "config.json",
+        key: `config.json:${key}`,
+        message: `Legacy v1 key '${key}' is no longer supported.`,
+        fix: `Move '${key}' into themes/<id>/manifest.jsonc. See ${MIGRATION_DOC} (Section "v1 → v2", step 3).`,
+      });
+    }
+  }
+  return findings;
+}
+
+function checkPerItemColor(
+  parsed: Record<string, unknown>,
+  arrayKey: "segments" | "rings",
+  manifestPath: string,
+): Finding[] {
+  const findings: Finding[] = [];
+  const items =
+    arrayKey === "segments"
+      ? ((parsed.segments ?? parsed.quadrants) as
+          | Array<Record<string, unknown>>
+          | undefined)
+      : (parsed.rings as Array<Record<string, unknown>> | undefined);
+  if (!Array.isArray(items)) return findings;
+
+  const singular = arrayKey === "segments" ? "segment" : "ring";
+  for (const [i, item] of items.entries()) {
+    if (!item || typeof item !== "object" || !("color" in item)) continue;
+    findings.push({
+      severity: "error",
+      file: "config.json",
+      key: `config.json:${arrayKey}[${i}].color`,
+      message: `Per-${singular} 'color' is no longer supported (${arrayKey}[${i}]: ${String(item.id ?? i)}).`,
+      fix: `Move ${singular} colors into manifest.jsonc → ${manifestPath}. See ${MIGRATION_DOC} (Section "v1 → v2", step 3).`,
+    });
+  }
+  return findings;
+}
+
+function readConfigJson(
+  filePath: string,
+): { parsed: Record<string, unknown> } | { parseError: Finding } | null {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf-8");
+  } catch {
+    // Not initialized — not a v1 problem, just nothing to detect.
+    return null;
+  }
+  try {
+    return { parsed: JSON.parse(raw) as Record<string, unknown> };
+  } catch (err) {
+    return {
+      parseError: {
+        severity: "error",
+        file: "config.json",
+        key: "config.json:parse",
+        message: `config.json is not valid JSON: ${(err as Error).message}`,
+        fix: `Fix the JSON syntax error before running migrate again. See ${MIGRATION_DOC}.`,
+      },
+    };
+  }
+}
+
+export function detectConfigJson(cwd: string): Finding[] {
+  const result = readConfigJson(join(cwd, "config.json"));
+  if (result === null) return [];
+  if ("parseError" in result) return [result.parseError];
+
+  const { parsed } = result;
+  const findings: Finding[] = [];
+  findings.push(...checkLegacyRootKeys(parsed));
+
+  if ("quadrants" in parsed && !("segments" in parsed)) {
+    findings.push({
+      severity: "warn",
+      file: "config.json",
+      key: "config.json:quadrants",
+      message: `Legacy key 'quadrants' is deprecated; use 'segments' instead.`,
+      fix: `Rename 'quadrants' → 'segments' in config.json. See ${MIGRATION_DOC} (Section "v1 → v2", step 2).`,
+    });
+  }
+
+  findings.push(...checkPerItemColor(parsed, "segments", "radar.segments"));
+  findings.push(...checkPerItemColor(parsed, "rings", "radar.rings"));
+
+  const defaultTheme = parsed.defaultTheme;
+  if (typeof defaultTheme !== "string" || defaultTheme.trim().length === 0) {
+    findings.push({
+      severity: "error",
+      file: "config.json",
+      key: "config.json:defaultTheme",
+      message: `Required field 'defaultTheme' is missing or empty.`,
+      fix: `Add "defaultTheme": "<theme-id>" referencing a theme under themes/<id>/. See ${MIGRATION_DOC} (Section "v1 → v2", step 1).`,
+    });
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// radar/**/*.md frontmatter
+// ---------------------------------------------------------------------------
+
+function collectMarkdownFiles(dirPath: string): string[] {
+  const files: string[] = [];
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+export function detectFrontmatter(cwd: string): Finding[] {
+  const radarDir = join(cwd, "radar");
+  const findings: Finding[] = [];
+
+  // Tolerate missing radar/ — project may use a different layout or be uninitialised.
+  try {
+    if (!statSync(radarDir).isDirectory()) return findings;
+  } catch {
+    return findings;
+  }
+
+  const files = collectMarkdownFiles(radarDir);
+  for (const filePath of files) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    let data: Record<string, unknown>;
+    try {
+      data = matter(content).data as Record<string, unknown>;
+    } catch {
+      // Malformed frontmatter — `validate` will report it. Skip silently here.
+      continue;
+    }
+
+    if (data.quadrant !== undefined && data.segment === undefined) {
+      const rel = relative(cwd, filePath);
+      findings.push({
+        severity: "warn",
+        file: rel,
+        key: `${rel}:quadrant`,
+        message: `Frontmatter uses legacy 'quadrant:' key.`,
+        fix: `Rename 'quadrant:' → 'segment:' in this file. See ${MIGRATION_DOC} (Section "v1 → v2", step 2).`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// themes/*/manifest.jsonc
+// ---------------------------------------------------------------------------
+
+export function detectThemes(cwd: string): Finding[] {
+  const themesDir = join(cwd, "themes");
+  const findings: Finding[] = [];
+
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(themesDir, { withFileTypes: true });
+  } catch {
+    // No themes/ — typical for v1 projects. The config-level errors
+    // above already nudge the user toward creating one.
+    return findings;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".")) continue; // skip .example etc.
+
+    const manifestPath = join(themesDir, entry.name, "manifest.jsonc");
+    let raw: string;
+    try {
+      raw = readFileSync(manifestPath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const parseErrors: ParseError[] = [];
+    const parsed = parseJsonc(raw, parseErrors, {
+      allowTrailingComma: true,
+    }) as Record<string, unknown> | undefined;
+
+    const rel = relative(cwd, manifestPath);
+
+    if (parseErrors.length > 0 || !parsed || typeof parsed !== "object") {
+      findings.push({
+        severity: "error",
+        file: rel,
+        key: `${rel}:parse`,
+        message: `manifest.jsonc could not be parsed.`,
+        fix: `Fix JSONC syntax errors. See data/themes/.example/manifest.jsonc for a reference.`,
+      });
+      continue;
+    }
+
+    if ("colorScheme" in parsed) {
+      findings.push({
+        severity: "error",
+        file: rel,
+        key: `${rel}:colorScheme`,
+        message: `Theme '${entry.name}' uses the legacy v1 'colorScheme' shape.`,
+        fix: `Rewrite this manifest using data/themes/.example/manifest.jsonc as a template. See ${MIGRATION_DOC} (Section "v1 → v2", step 3).`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export function detectAll(cwd: string): MigrationReport {
+  const findings = [
+    ...detectConfigJson(cwd),
+    ...detectFrontmatter(cwd),
+    ...detectThemes(cwd),
+  ];
+  const hasErrors = findings.some((f) => f.severity === "error");
+  return {
+    findings,
+    hasV1Markers: findings.length > 0,
+    hasErrors,
+  };
+}

--- a/packages/techradar/bin/migrateThemes.ts
+++ b/packages/techradar/bin/migrateThemes.ts
@@ -1,0 +1,478 @@
+/**
+ * v1 → v2 theme extraction (Layer 3 of the migration plan).
+ *
+ * Lifts the v1 inline theming keys out of `config.json` into a fresh
+ * `themes/<id>/manifest.jsonc` and stamps `defaultTheme: "<id>"` into
+ * the now-stripped config. Keys handled:
+ *   - root `colors.{foreground,background,highlight,content,text,link,border,tag}`
+ *     → `cssVariables.<key>`
+ *   - root `backgroundImage` → `background.image` (asset is copied into the
+ *     theme folder when present on disk)
+ *   - root `backgroundOpacity` → `background.opacity`
+ *   - `segments[].color` → `radar.segments[]`
+ *   - `rings[].color`    → `radar.rings[]`
+ *
+ * Keys the v2 schema requires that v1 never had (`surface`, `footer`,
+ * `shading`, `frosted`, plus the optional `chips` block) get sensible
+ * defaults derived from background/foreground or omitted; the user can
+ * tune them later.
+ *
+ * MUST NOT import `src/lib/config.ts` or `scripts/theme/scanner.ts` for the
+ * same reason as the sibling migrate modules: both throw on legacy keys.
+ */
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import type { ApplyError, ChangeRecord } from "./migrateApply";
+
+export type ThemeMode = "light" | "dark";
+
+export interface ThemeExtractInput {
+  cwd: string;
+  /** URL-safe slug, becomes the theme directory name and `defaultTheme` value. */
+  themeId: string;
+  /** Human-readable name shown in the in-app theme switcher. */
+  label: string;
+  /** Modes the theme provides values for; 1–2 entries. */
+  supports: ThemeMode[];
+  /** The mode picked when no user preference exists; MUST be in `supports`. */
+  defaultMode: ThemeMode;
+  /** When false, plan only — no backup, no writes. Default true. */
+  write?: boolean;
+}
+
+export interface ThemeExtractResult {
+  changes: ChangeRecord[];
+  /** Backup directory relative to cwd, or null if nothing was written. */
+  backupDir: string | null;
+  errors: ApplyError[];
+  /** Path to the generated manifest, relative to cwd, or null if no extraction happened. */
+  manifestPath: string | null;
+  /** v1 `colors` keys we did not map (they have no v2 cssVariables equivalent). */
+  unmappedColors: string[];
+}
+
+const BACKUP_ROOT = ".techradar-migrate-backup";
+
+const V1_COLOR_KEYS_TO_CSS_VAR = [
+  "foreground",
+  "background",
+  "highlight",
+  "content",
+  "text",
+  "link",
+  "border",
+  "tag",
+] as const;
+
+/**
+ * Per-mode defaults for every v2 cssVariable. Used to fill any key the
+ * v1 config did not provide (so a starter manifest is always usable as-is).
+ * Values are sourced from `data/themes/.example/manifest.jsonc`.
+ */
+const CSS_VAR_DEFAULTS = {
+  foreground: { light: "#111111", dark: "#FFFFFF" },
+  background: { light: "#F6F6F6", dark: "#000000" },
+  highlight: { light: "#0047FF", dark: "#88B5FF" },
+  content: { light: "#555555", dark: "#CCCCCC" },
+  text: { light: "#666666", dark: "#999999" },
+  link: { light: "#0047FF", dark: "#88B5FF" },
+  border: { light: "#D0D0D0", dark: "#333333" },
+  tag: { light: "#E5E5E5", dark: "#333333" },
+  surface: { light: "#FFFFFF", dark: "#111111" },
+  footer: { light: "#FFFFFF", dark: "#212225" },
+  shading: { light: "rgba(20, 20, 20, 0.2)", dark: "rgba(20, 20, 20, 0.67)" },
+  frosted: {
+    light: "rgba(255, 255, 255, 0.5)",
+    dark: "rgba(40, 40, 40, 0.35)",
+  },
+} as const;
+
+// =============================================================================
+// JSON helpers
+// =============================================================================
+
+function readConfig(
+  cwd: string,
+): { ok: true; raw: Record<string, unknown> } | { ok: false; error: string } {
+  const path = join(cwd, "config.json");
+  if (!existsSync(path)) {
+    return { ok: false, error: "config.json not found" };
+  }
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch (e) {
+    return {
+      ok: false,
+      error: `config.json read failed: ${(e as Error).message}`,
+    };
+  }
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return { ok: false, error: "config.json is not a JSON object" };
+    }
+    return { ok: true, raw: parsed as Record<string, unknown> };
+  } catch (e) {
+    return {
+      ok: false,
+      error: `config.json is not valid JSON: ${(e as Error).message}`,
+    };
+  }
+}
+
+function asObject(v: unknown): Record<string, unknown> | null {
+  if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+    return v as Record<string, unknown>;
+  }
+  return null;
+}
+
+function asArray(v: unknown): unknown[] | null {
+  return Array.isArray(v) ? v : null;
+}
+
+// =============================================================================
+// Manifest builder
+// =============================================================================
+
+/**
+ * Wrap a single color value as a per-mode object when the theme supports
+ * both modes; pass through as a plain string for single-mode themes.
+ * v1 only had one palette, so we duplicate into both modes — the user is
+ * told to tune the dark mode separately afterwards.
+ */
+function asModeValue(value: unknown, supports: ThemeMode[]): unknown {
+  if (typeof value !== "string") return value;
+  if (supports.length === 1) return value;
+  const obj: Partial<Record<ThemeMode, string>> = {};
+  for (const mode of supports) obj[mode] = value;
+  return obj;
+}
+
+function buildCssVariables(
+  v1Colors: Record<string, unknown>,
+  supports: ThemeMode[],
+): { cssVariables: Record<string, unknown>; unmapped: string[] } {
+  const cssVariables: Record<string, unknown> = {};
+  const unmapped: string[] = [];
+  for (const key of V1_COLOR_KEYS_TO_CSS_VAR) {
+    if (key in v1Colors) {
+      cssVariables[key] = asModeValue(v1Colors[key], supports);
+    }
+  }
+  for (const presentKey of Object.keys(v1Colors)) {
+    if (!(V1_COLOR_KEYS_TO_CSS_VAR as readonly string[]).includes(presentKey)) {
+      unmapped.push(presentKey);
+    }
+  }
+  for (const [key, defaults] of Object.entries(CSS_VAR_DEFAULTS)) {
+    if (cssVariables[key] !== undefined) continue;
+    if (supports.length === 1) {
+      cssVariables[key] = defaults[supports[0]];
+    } else {
+      const obj: Partial<Record<ThemeMode, string>> = {};
+      for (const mode of supports) obj[mode] = defaults[mode];
+      cssVariables[key] = obj;
+    }
+  }
+  return { cssVariables, unmapped };
+}
+
+function buildBackground(
+  raw: Record<string, unknown>,
+  supports: ThemeMode[],
+): Record<string, unknown> | null {
+  const image = raw.backgroundImage;
+  const opacity = raw.backgroundOpacity;
+  if (image === undefined && opacity === undefined) return null;
+  const block: Record<string, unknown> = {};
+  if (typeof image === "string") {
+    block.image = asModeValue(basename(image), supports);
+  }
+  if (typeof opacity === "number") {
+    block.opacity = asModeValue(opacity, supports);
+  }
+  return Object.keys(block).length > 0 ? block : null;
+}
+
+function buildRadarPalette(
+  arr: unknown[] | null,
+  supports: ThemeMode[],
+): unknown[] {
+  if (!arr) return [];
+  return arr
+    .map((entry) => {
+      const obj = asObject(entry);
+      if (!obj || typeof obj.color !== "string") return null;
+      return asModeValue(obj.color, supports);
+    })
+    .filter((v) => v !== null);
+}
+
+function buildManifest(
+  raw: Record<string, unknown>,
+  input: ThemeExtractInput,
+): { manifest: Record<string, unknown>; unmappedColors: string[] } {
+  const v1Colors = asObject(raw.colors) ?? {};
+  const { cssVariables, unmapped } = buildCssVariables(
+    v1Colors,
+    input.supports,
+  );
+  const background = buildBackground(raw, input.supports);
+  // Resolve segments via v2 key first, then v1 alias, matching detector logic.
+  const segments = asArray(raw.segments) ?? asArray(raw.quadrants);
+  const rings = asArray(raw.rings);
+  const radarSegments = buildRadarPalette(segments, input.supports);
+  const radarRings = buildRadarPalette(rings, input.supports);
+  const manifest: Record<string, unknown> = {
+    label: input.label,
+    supports: input.supports,
+    default: input.defaultMode,
+    cssVariables,
+  };
+  if (background) manifest.background = background;
+  manifest.radar = { segments: radarSegments, rings: radarRings };
+  return { manifest, unmappedColors: unmapped };
+}
+
+// =============================================================================
+// Config strip
+// =============================================================================
+
+const CONFIG_STRIP_KEYS = [
+  "colors",
+  "backgroundImage",
+  "backgroundOpacity",
+] as const;
+
+function stripConfigForV2(
+  raw: Record<string, unknown>,
+  themeId: string,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  // Insert defaultTheme near the top: after $schema (if any), else first.
+  if (raw.$schema !== undefined) out.$schema = raw.$schema;
+  out.defaultTheme = themeId;
+  for (const [key, value] of Object.entries(raw)) {
+    if (key === "$schema" || key === "defaultTheme") continue;
+    if ((CONFIG_STRIP_KEYS as readonly string[]).includes(key)) continue;
+    if (key === "segments" || key === "quadrants") {
+      out[key] = stripPerItemColor(value);
+    } else if (key === "rings") {
+      out[key] = stripPerItemColor(value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+function stripPerItemColor(value: unknown): unknown {
+  const arr = asArray(value);
+  if (!arr) return value;
+  return arr.map((entry) => {
+    const obj = asObject(entry);
+    if (!obj || !("color" in obj)) return entry;
+    const rest: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(obj)) {
+      if (key !== "color") rest[key] = val;
+    }
+    return rest;
+  });
+}
+
+// =============================================================================
+// Backup & write
+// =============================================================================
+
+function backupTimestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+}
+
+function snapshotFile(cwd: string, backupDir: string, relPath: string): void {
+  const src = join(cwd, relPath);
+  if (!existsSync(src)) return;
+  const dest = join(cwd, backupDir, relPath);
+  mkdirSync(dirname(dest), { recursive: true });
+  copyFileSync(src, dest);
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+const EMPTY_RESULT: ThemeExtractResult = {
+  changes: [],
+  backupDir: null,
+  errors: [],
+  manifestPath: null,
+  unmappedColors: [],
+};
+
+/**
+ * Pure orchestrator. Reads config.json, builds manifest + stripped config,
+ * optionally backs up & writes to disk. Returns a structured result for
+ * the CLI to render (and for tests to assert on).
+ */
+export function extractThemeFromConfig(
+  input: ThemeExtractInput,
+): ThemeExtractResult {
+  const { cwd, themeId, write = true } = input;
+  if (!input.supports.includes(input.defaultMode)) {
+    return {
+      ...EMPTY_RESULT,
+      errors: [
+        {
+          file: "(input)",
+          message: `defaultMode '${input.defaultMode}' is not in supports [${input.supports.join(", ")}].`,
+        },
+      ],
+    };
+  }
+
+  const read = readConfig(cwd);
+  if (!read.ok) {
+    return {
+      ...EMPTY_RESULT,
+      errors: [{ file: "config.json", message: read.error }],
+    };
+  }
+  const raw = read.raw;
+  const hasV1Theming =
+    raw.colors !== undefined ||
+    raw.backgroundImage !== undefined ||
+    raw.backgroundOpacity !== undefined ||
+    hasPerItemColor(raw.segments) ||
+    hasPerItemColor(raw.quadrants) ||
+    hasPerItemColor(raw.rings);
+
+  const { manifest, unmappedColors } = buildManifest(raw, input);
+  const strippedConfig = stripConfigForV2(raw, themeId);
+
+  const changes: ChangeRecord[] = [];
+  const themeRel = join("themes", themeId);
+  const manifestRel = join(themeRel, "manifest.jsonc");
+  changes.push({
+    file: manifestRel,
+    description: hasV1Theming
+      ? `Created v2 theme manifest from v1 config keys`
+      : `Created starter v2 theme manifest`,
+  });
+  changes.push({
+    file: "config.json",
+    description: `Added defaultTheme: "${themeId}" and stripped v1 theming keys`,
+  });
+  const assetCopies = planAssetCopies(cwd, raw, themeRel);
+  for (const copy of assetCopies) {
+    changes.push({
+      file: copy.dest,
+      description: `Copied background asset from ${copy.src}`,
+    });
+  }
+
+  if (!write) {
+    return {
+      changes,
+      backupDir: null,
+      errors: [],
+      manifestPath: manifestRel,
+      unmappedColors,
+    };
+  }
+
+  const errors: ApplyError[] = [];
+  const backupDir = join(BACKUP_ROOT, backupTimestamp());
+  try {
+    snapshotFile(cwd, backupDir, "config.json");
+  } catch (e) {
+    errors.push({
+      file: "config.json",
+      message: `backup failed: ${(e as Error).message}`,
+    });
+  }
+
+  try {
+    const manifestAbs = join(cwd, manifestRel);
+    mkdirSync(dirname(manifestAbs), { recursive: true });
+    writeFileSync(
+      manifestAbs,
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      "utf8",
+    );
+  } catch (e) {
+    errors.push({ file: manifestRel, message: (e as Error).message });
+  }
+
+  try {
+    writeFileSync(
+      join(cwd, "config.json"),
+      `${JSON.stringify(strippedConfig, null, 2)}\n`,
+      "utf8",
+    );
+  } catch (e) {
+    errors.push({ file: "config.json", message: (e as Error).message });
+  }
+
+  for (const copy of assetCopies) {
+    try {
+      const destAbs = join(cwd, copy.dest);
+      mkdirSync(dirname(destAbs), { recursive: true });
+      copyFileSync(join(cwd, copy.src), destAbs);
+    } catch (e) {
+      errors.push({ file: copy.dest, message: (e as Error).message });
+    }
+  }
+
+  return {
+    changes,
+    backupDir,
+    errors,
+    manifestPath: manifestRel,
+    unmappedColors,
+  };
+}
+
+interface AssetCopy {
+  src: string;
+  dest: string;
+}
+
+function planAssetCopies(
+  cwd: string,
+  raw: Record<string, unknown>,
+  themeRel: string,
+): AssetCopy[] {
+  const image = raw.backgroundImage;
+  if (typeof image !== "string") return [];
+  // v1 backgroundImage paths are typically absolute-ish (e.g. /background.jpg)
+  // resolved against /public. Accept both leading-slash and bare filenames.
+  const stripped = image.replace(/^\/+/, "");
+  const candidates = [join("public", stripped), stripped];
+  for (const candidate of candidates) {
+    if (existsSync(join(cwd, candidate))) {
+      return [{ src: candidate, dest: join(themeRel, basename(stripped)) }];
+    }
+  }
+  return [];
+}
+
+function hasPerItemColor(value: unknown): boolean {
+  const arr = asArray(value);
+  if (!arr) return false;
+  return arr.some((entry) => {
+    const obj = asObject(entry);
+    return obj !== null && "color" in obj;
+  });
+}

--- a/packages/techradar/bin/techradar.ts
+++ b/packages/techradar/bin/techradar.ts
@@ -15,6 +15,9 @@ import { watch } from "chokidar";
 import { defineCommand, runMain } from "citty";
 import consola from "consola";
 import { execa, execaSync } from "execa";
+import { applyMechanicalRenames } from "./migrateApply";
+import { detectAll, type Finding } from "./migrateDetect";
+import { extractThemeFromConfig, type ThemeMode } from "./migrateThemes";
 import { sanitizeShadowTsconfig } from "./sanitizeShadowTsconfig";
 
 // ---------------------------------------------------------------------------
@@ -527,6 +530,294 @@ const devCommand = defineCommand({
 // Main command
 // ---------------------------------------------------------------------------
 
+function formatFinding(f: Finding): string {
+  const icon = f.severity === "error" ? "✖" : "⚠";
+  return `  ${icon} ${f.key}\n      ${f.message}\n      → ${f.fix}`;
+}
+
+function printFindings(findings: Finding[]): void {
+  const errors = findings.filter((f) => f.severity === "error");
+  const warns = findings.filter((f) => f.severity === "warn");
+  if (errors.length > 0) {
+    consola.error(`${errors.length} blocking issue(s) (v2 build will fail):`);
+    for (const f of errors) consola.log(formatFinding(f));
+  }
+  if (warns.length > 0) {
+    consola.warn(
+      `${warns.length} deprecation(s) (v2 still accepts these via shims):`,
+    );
+    for (const f of warns) consola.log(formatFinding(f));
+  }
+}
+
+function runMigrateApply(report: ReturnType<typeof detectAll>): void {
+  consola.start("Applying mechanical rewrites…");
+  const result = applyMechanicalRenames({ cwd: CWD });
+
+  if (result.changes.length === 0) {
+    consola.info(
+      "No mechanical rewrites available. Remaining findings need manual edits — see MIGRATION.md.",
+    );
+    printFindings(report.findings);
+    if (report.hasErrors) process.exit(1);
+    return;
+  }
+
+  for (const c of result.changes) {
+    consola.log(`  • ${c.file} — ${c.description}`);
+  }
+  if (result.backupDir) {
+    consola.info(
+      `Backup written to ${result.backupDir}/. Add that path to .gitignore or commit it. Restore by copying files back into place.`,
+    );
+  }
+  for (const e of result.errors) {
+    consola.error(`Failed to write ${e.file}: ${e.message}`);
+  }
+
+  consola.start("Re-scanning for remaining v1 markers…");
+  const after = detectAll(CWD);
+  if (!after.hasV1Markers) {
+    consola.success("All v1 markers resolved. Run `npx techradar build`.");
+    if (result.errors.length > 0) process.exit(1);
+    return;
+  }
+
+  consola.warn(
+    `${after.findings.length} finding(s) remain (theme & manual steps).`,
+  );
+  printFindings(after.findings);
+  consola.info(
+    `See MIGRATION.md (Section "v1 → v2", step 3) for the theme extraction recipe.`,
+  );
+  if (after.hasErrors || result.errors.length > 0) process.exit(1);
+}
+
+interface ExtractThemeArgs {
+  "theme-id"?: string;
+  "theme-label"?: string;
+  "theme-supports"?: string;
+  "theme-default"?: string;
+}
+
+function parseSupports(input: string): ThemeMode[] {
+  const tokens = input
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+  const valid: ThemeMode[] = [];
+  for (const t of tokens) {
+    if (t === "light" || t === "dark") {
+      if (!valid.includes(t)) valid.push(t);
+    }
+  }
+  return valid;
+}
+
+async function resolveExtractThemeInputs(args: ExtractThemeArgs): Promise<{
+  themeId: string;
+  label: string;
+  supports: ThemeMode[];
+  defaultMode: ThemeMode;
+} | null> {
+  const themeId =
+    args["theme-id"] ??
+    (await consola.prompt("Theme id (URL-safe slug, e.g. 'acme'):", {
+      type: "text",
+      placeholder: "acme",
+    }));
+  if (typeof themeId !== "string" || themeId.trim() === "") {
+    consola.fatal("theme-id is required.");
+    return null;
+  }
+
+  const label =
+    args["theme-label"] ??
+    (await consola.prompt("Human-readable theme label:", {
+      type: "text",
+      default: themeId,
+    }));
+  if (typeof label !== "string" || label.trim() === "") {
+    consola.fatal("theme-label is required.");
+    return null;
+  }
+
+  let supports: ThemeMode[];
+  if (args["theme-supports"]) {
+    supports = parseSupports(args["theme-supports"]);
+  } else {
+    const picked = await consola.prompt(
+      "Which color modes does this theme support?",
+      {
+        type: "select",
+        options: [
+          { label: "light + dark", value: "light,dark" },
+          { label: "light only", value: "light" },
+          { label: "dark only", value: "dark" },
+        ],
+      },
+    );
+    supports = parseSupports(String(picked));
+  }
+  if (supports.length === 0) {
+    consola.fatal(
+      "theme-supports must include at least one of 'light' or 'dark'.",
+    );
+    return null;
+  }
+
+  let defaultMode: ThemeMode;
+  if (args["theme-default"]) {
+    const v = args["theme-default"].trim().toLowerCase();
+    if (v !== "light" && v !== "dark") {
+      consola.fatal("theme-default must be 'light' or 'dark'.");
+      return null;
+    }
+    defaultMode = v;
+  } else if (supports.length === 1) {
+    defaultMode = supports[0];
+  } else {
+    const picked = await consola.prompt(
+      "Default mode (when no user preference):",
+      {
+        type: "select",
+        options: supports.map((m) => ({ label: m, value: m })),
+      },
+    );
+    defaultMode = String(picked) === "dark" ? "dark" : "light";
+  }
+  if (!supports.includes(defaultMode)) {
+    consola.fatal(
+      `theme-default '${defaultMode}' must be one of the supported modes [${supports.join(", ")}].`,
+    );
+    return null;
+  }
+
+  return {
+    themeId: themeId.trim(),
+    label: label.trim(),
+    supports,
+    defaultMode,
+  };
+}
+
+async function runMigrateExtractTheme(args: ExtractThemeArgs): Promise<void> {
+  const inputs = await resolveExtractThemeInputs(args);
+  if (!inputs) {
+    process.exit(1);
+    return;
+  }
+
+  consola.start(
+    `Extracting v1 theming into themes/${inputs.themeId}/manifest.jsonc…`,
+  );
+  const result = extractThemeFromConfig({ cwd: CWD, ...inputs });
+
+  for (const c of result.changes) {
+    consola.log(`  • ${c.file} — ${c.description}`);
+  }
+  if (result.backupDir) {
+    consola.info(
+      `Backup written to ${result.backupDir}/. Add that path to .gitignore or commit it. Restore by copying files back into place.`,
+    );
+  }
+  for (const e of result.errors) {
+    consola.error(`Failed: ${e.file}: ${e.message}`);
+  }
+  if (result.unmappedColors.length > 0) {
+    consola.warn(
+      `Skipped v1 'colors' keys with no v2 equivalent: ${result.unmappedColors.join(", ")}. Add them under cssVariables in the new manifest if you want to keep them.`,
+    );
+  }
+  if (inputs.supports.length === 2) {
+    consola.info(
+      "Dual-mode theme: every color value was duplicated into {light, dark}. Tune the dark-mode values in the new manifest to match your brand.",
+    );
+  }
+
+  consola.start("Re-scanning for remaining v1 markers…");
+  const after = detectAll(CWD);
+  if (!after.hasV1Markers) {
+    consola.success(
+      `Theme extracted. Run \`npx techradar build\` to verify, then commit themes/${inputs.themeId}/.`,
+    );
+    if (result.errors.length > 0) process.exit(1);
+    return;
+  }
+  consola.warn(`${after.findings.length} finding(s) remain.`);
+  printFindings(after.findings);
+  if (after.hasErrors || result.errors.length > 0) process.exit(1);
+}
+
+const migrateCommand = defineCommand({
+  meta: {
+    name: "migrate",
+    description: "Detect (and optionally apply) v1 → v2 configuration upgrades",
+  },
+  args: {
+    apply: {
+      type: "boolean",
+      description:
+        "Apply the safe mechanical rewrites (quadrants→segments, frontmatter rename). A backup is written under .techradar-migrate-backup/<timestamp>/.",
+      default: false,
+    },
+    "extract-theme": {
+      type: "boolean",
+      description:
+        "Lift v1 inline theming (colors, backgroundImage, segments[].color, rings[].color) into a new themes/<id>/manifest.jsonc and stamp defaultTheme into config.json. Prompts interactively for theme id / label / modes if not supplied via flags. A backup is written under .techradar-migrate-backup/<timestamp>/.",
+      default: false,
+    },
+    "theme-id": {
+      type: "string",
+      description: "Theme id (URL-safe slug) for --extract-theme.",
+    },
+    "theme-label": {
+      type: "string",
+      description: "Human-readable theme label for --extract-theme.",
+    },
+    "theme-supports": {
+      type: "string",
+      description:
+        "Modes the theme supports for --extract-theme: 'light', 'dark', or 'light,dark'.",
+    },
+    "theme-default": {
+      type: "string",
+      description:
+        "Default mode for --extract-theme (must be one of theme-supports).",
+    },
+  },
+  async run({ args }) {
+    const report = detectAll(CWD);
+
+    if (!report.hasV1Markers) {
+      consola.success(
+        "No v1 markers detected. Project looks like a clean v2 setup.",
+      );
+      return;
+    }
+
+    if (args["extract-theme"]) {
+      await runMigrateExtractTheme(args);
+      return;
+    }
+
+    if (!args.apply) {
+      printFindings(report.findings);
+      consola.info(
+        `See MIGRATION.md for the full v1 → v2 recipe. Re-run with \`--apply\` to perform the safe mechanical rewrites${
+          report.hasErrors
+            ? ", then `--extract-theme` to lift v1 colors into a theme manifest"
+            : ""
+        }.${report.hasErrors ? " Exiting non-zero for CI." : ""}`,
+      );
+      if (report.hasErrors) process.exit(1);
+      return;
+    }
+
+    runMigrateApply(report);
+  },
+});
+
 const main = defineCommand({
   meta: {
     name: "techradar",
@@ -546,14 +837,26 @@ const main = defineCommand({
     serve: serveCommand,
     build: buildCommand,
     dev: devCommand,
+    migrate: migrateCommand,
   },
   setup({ args, rawArgs }) {
-    // Skip setup for init — it handles its own bootstrapping
-    if (rawArgs.includes("init")) return;
+    // init bootstraps itself; migrate is read-only and must skip ensureBuildDir (npm install).
+    if (rawArgs.includes("init") || rawArgs.includes("migrate")) return;
 
     if (!isInitialized()) {
       consola.fatal("Project not initialized. Run `npx techradar init` first.");
       process.exit(1);
+    }
+
+    const report = detectAll(CWD);
+    if (report.hasErrors) {
+      const errCount = report.findings.filter(
+        (f) => f.severity === "error",
+      ).length;
+      consola.warn(
+        `Detected v1 configuration (${errCount} blocking issue(s)). ` +
+          `Run \`npx techradar migrate\` for a guided upgrade. See MIGRATION.md.`,
+      );
     }
 
     ensureBuildDir();

--- a/packages/techradar/cspell-words.txt
+++ b/packages/techradar/cspell-words.txt
@@ -666,3 +666,4 @@ relitigating
 codemod
 codemods
 synthwave
+rgba

--- a/packages/techradar/scripts/theme/__tests__/scanner.test.ts
+++ b/packages/techradar/scripts/theme/__tests__/scanner.test.ts
@@ -120,7 +120,7 @@ describe("scanThemes", () => {
         defaultTheme: "legacy",
       }),
     ).toThrow(
-      "Theme 'legacy' uses the legacy v1 schema (colorScheme field). PDS v4 + theme×mode requires the new shape — see data/themes/.example/README.md for the new schema. No automated migration is provided; rewrite manifest.jsonc by hand.",
+      "Theme 'legacy' uses the legacy v1 schema (colorScheme field). PDS v4 + theme×mode requires the new shape — see data/themes/.example/manifest.jsonc for an annotated reference and MIGRATION.md (Section 'v1 → v2', step 3) for the field-by-field mapping. No automated migration is provided; rewrite manifest.jsonc by hand.",
     );
   });
 

--- a/packages/techradar/scripts/theme/scanner.ts
+++ b/packages/techradar/scripts/theme/scanner.ts
@@ -16,8 +16,9 @@ export interface ScannerOptions {
 const LEGACY_SCHEMA_ERROR = (id: string) =>
   `Theme '${id}' uses the legacy v1 schema (colorScheme field). ` +
   "PDS v4 + theme×mode requires the new shape — see " +
-  "data/themes/.example/README.md for the new schema. No automated migration " +
-  "is provided; rewrite manifest.jsonc by hand.";
+  "data/themes/.example/manifest.jsonc for an annotated reference and " +
+  "MIGRATION.md (Section 'v1 → v2', step 3) for the field-by-field mapping. " +
+  "No automated migration is provided; rewrite manifest.jsonc by hand.";
 
 function parseThemeFile(themePath: string, id: string): unknown {
   const raw = fs.readFileSync(themePath, "utf8");

--- a/packages/techradar/src/lib/config.ts
+++ b/packages/techradar/src/lib/config.ts
@@ -40,17 +40,21 @@ if (userConfig.quadrants !== undefined && userConfig.segments === undefined) {
 }
 
 // T14/T18: Legacy key detection — BREAKING change.
-// These keys were removed in favour of the data/themes/ folder system.
+// These keys were removed in favour of the themes/ folder system.
 const VERSION = packageJson.version;
 const LEGACY_ROOT_KEYS = [
   "colors",
   "backgroundImage",
   "backgroundOpacity",
 ] as const;
+const MIGRATION_HINT =
+  "Define colors in a theme file under themes/<id>/manifest.jsonc instead. " +
+  "See MIGRATION.md (Section 'v1 → v2') for the field-by-field mapping.";
+
 for (const key of LEGACY_ROOT_KEYS) {
   if (key in userConfig) {
     throw new Error(
-      `config.json: '${key}' is no longer supported in v${VERSION}. Define colors in a theme file under data/themes/ instead.`,
+      `config.json: '${key}' is no longer supported in v${VERSION}. ${MIGRATION_HINT}`,
     );
   }
 }
@@ -60,7 +64,7 @@ if (
   )
 ) {
   throw new Error(
-    `config.json: 'segments[].color' is no longer supported in v${VERSION}. Define colors in a theme file under data/themes/ instead.`,
+    `config.json: 'segments[].color' is no longer supported in v${VERSION}. ${MIGRATION_HINT}`,
   );
 }
 if (
@@ -69,7 +73,7 @@ if (
   )
 ) {
   throw new Error(
-    `config.json: 'rings[].color' is no longer supported in v${VERSION}. Define colors in a theme file under data/themes/ instead.`,
+    `config.json: 'rings[].color' is no longer supported in v${VERSION}. ${MIGRATION_HINT}`,
   );
 }
 
@@ -80,7 +84,9 @@ if (
   config.defaultTheme.length === 0
 ) {
   throw new Error(
-    "config.json: 'defaultTheme' is required and must be a non-empty string identifying a theme under data/themes/. It may optionally include ':light' or ':dark'.",
+    "config.json: 'defaultTheme' is required and must be a non-empty string identifying a theme under themes/<id>/. " +
+      "It may optionally include ':light' or ':dark' to pin the initial mode (e.g. 'acme:dark'). " +
+      "See MIGRATION.md (Section 'v1 → v2', step 1) for picking a theme id.",
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a guided v1 → v2 upgrade path for techradar consumer projects via a new `npx techradar migrate` CLI plus complete migration documentation.

## What changed

**New CLI: `npx techradar migrate`**
- **Detect-only (default)** — Scans `config.json`, item frontmatter, and theme manifests for legacy v1 keys. Reports each finding with severity (`error` = v2 build will fail; `warn` = soft-shimmed) plus a fix hint pointing at the right MIGRATION.md section.
- **`--apply`** — Performs safe mechanical rewrites: `quadrants` → `segments` in `config.json`, `quadrant:` → `segment:` in radar item frontmatter. Modified files are mirrored into `.techradar-migrate-backup/<timestamp>/` before any write so the operation is fully reversible.
- **`--extract-theme`** — Interactively (or via `--theme-id`/`--theme-label`/`--theme-supports`/`--theme-default` flags) generates `data/themes/<id>/manifest.jsonc` from legacy `colors`, `backgroundImage`, `segments[].color`, and `rings[].color` keys. Copies the background asset, strips the legacy keys from `config.json`, and inserts the matching `defaultTheme`. Falls back to defaults from `data/themes/.example/` for any unmapped CSS variables and reports `unmappedColors` to the user.

**Auto-nudge in `setup()`** — Any techradar command other than `init`/`migrate` now detects v1 markers and warns the user to run `npx techradar migrate` before proceeding.

**Improved error messages** — `src/lib/config.ts` and the theme scanner now reference MIGRATION.md (with section anchors) instead of dead-ending the user.

**Documentation**
- New `packages/techradar/MIGRATION.md` — full v1 → v2 recipe with the `migrate`, `--apply`, and `--extract-theme` workflows.
- `README.md` — adds the migration link in the header, updates the example `config.json` to the v2 shape, and documents the new CLI flags.

## Verification

| Check | Result |
|---|---|
| `vitest bin/` | 62/62 pass (46 prior + 16 new) |
| `tsc --noEmit` | clean |
| `biome check` | clean |
| `check:arch` (5 sensors) | all green |
| `check:quality` (sonar/knip/jscpd/naming/coverage/spell) | all green |

## Notes

Squashed delivery of four logical phases (P1 docs/errors → P2 detect → P3 apply → P4 extract-theme) into one commit per request.