### PR TITLE
fix(techradar): mobile improvements for showcase tiles and Spotlight search

### DIFF
--- a/packages/techradar/bundle-budget.json
+++ b/packages/techradar/bundle-budget.json
@@ -1,6 +1,6 @@
 {
   "$schema": "Hand-edited bundle thresholds. Bump only when a deliberate cost is justified.",
   "maxTotalJsBytes": 2700000,
-  "maxTotalCssBytes": 73500,
+  "maxTotalCssBytes": 76000,
   "maxChunkBytes": 293000
 }

--- a/packages/techradar/src/__tests__/pages/index.test.tsx
+++ b/packages/techradar/src/__tests__/pages/index.test.tsx
@@ -171,11 +171,13 @@ describe("Home page", () => {
     expect(screen.getByTestId("mobile-segment-nav")).toBeInTheDocument();
   });
 
-  it("passes segments to MobileSegmentNav", () => {
+  it("passes segments, items, and rings to MobileSegmentNav", () => {
     render(<Home />);
 
     expect(mockData.mobileNavProps).toHaveBeenCalledWith({
       segments,
+      items: expect.any(Array),
+      rings,
     });
   });
 

--- a/packages/techradar/src/components/MobileSegmentNav/MobileSegmentNav.module.scss
+++ b/packages/techradar/src/components/MobileSegmentNav/MobileSegmentNav.module.scss
@@ -2,9 +2,13 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: $pds-spacing-static-small;
-  padding: $pds-spacing-fluid-small $pds-spacing-static-medium;
+  grid-template-columns: 1fr;
+  gap: $pds-spacing-static-medium;
+  padding: $pds-spacing-fluid-small $pds-spacing-fluid-medium;
+
+  @media (min-width: 480px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
 
   @media (min-width: 768px) {
     display: none;
@@ -14,6 +18,13 @@
 .colorSwatch {
   width: 100%;
   height: 100%;
+}
+
+.tagRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $pds-spacing-static-x-small;
+  padding: $pds-spacing-static-x-small;
 }
 
 .footerText {

--- a/packages/techradar/src/components/MobileSegmentNav/MobileSegmentNav.tsx
+++ b/packages/techradar/src/components/MobileSegmentNav/MobileSegmentNav.tsx
@@ -1,20 +1,36 @@
-import { PLinkTile, PText } from "@porsche-design-system/components-react/ssr";
+import {
+  PLinkTile,
+  PTag,
+  PText,
+} from "@porsche-design-system/components-react/ssr";
 
 import { useTheme } from "@/lib/ThemeContext";
-import type { Segment } from "@/lib/types";
+import type { Item, Ring, Segment } from "@/lib/types";
 import { assetUrl, cn } from "@/lib/utils";
 
 import styles from "./MobileSegmentNav.module.scss";
 
 interface MobileSegmentNavProps {
   segments: Segment[];
+  items: Item[];
+  rings: Ring[];
 }
 
-export function MobileSegmentNav({ segments }: MobileSegmentNavProps) {
+export function MobileSegmentNav({
+  segments,
+  items,
+  rings,
+}: MobileSegmentNavProps) {
   const { theme } = useTheme();
   return (
     <nav aria-label="Segments" className={styles.grid}>
       {segments.map((q, idx) => {
+        const segmentItems = items.filter((item) => item.segment === q.id);
+        const ringCounts = rings.map((ring) => ({
+          ring,
+          count: segmentItems.filter((item) => item.ring === ring.id).length,
+        }));
+
         const linkTileProps = {
           href: assetUrl(`/${q.id}`),
           label: "Explore",
@@ -22,12 +38,26 @@ export function MobileSegmentNav({ segments }: MobileSegmentNavProps) {
           size: "inherit" as const,
           compact: true,
           weight: "semi-bold" as const,
-          aspectRatio: "4/3" as const,
+          aspectRatio: "16/9" as const,
           gradient: true,
         };
 
         return (
           <PLinkTile key={q.id} {...linkTileProps}>
+            <div slot="header" className={styles.tagRow}>
+              {ringCounts
+                .filter(({ count }) => count > 0)
+                .map(({ ring, count }) => (
+                  <PTag
+                    key={ring.id}
+                    variant="info-frosted"
+                    compact
+                    aria-label={`${count} ${ring.title}`}
+                  >
+                    {ring.title} {count}
+                  </PTag>
+                ))}
+            </div>
             <div
               className={styles.colorSwatch}
               style={{ backgroundColor: theme.radar.segments[idx] }}

--- a/packages/techradar/src/components/MobileSegmentNav/__tests__/MobileSegmentNav.test.tsx
+++ b/packages/techradar/src/components/MobileSegmentNav/__tests__/MobileSegmentNav.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { useTheme } from "@/lib/ThemeContext";
-import type { Segment } from "@/lib/types";
+import { Flag, type Item, type Ring, type Segment } from "@/lib/types";
 import { MobileSegmentNav } from "../MobileSegmentNav";
 
 vi.mock("@/lib/ThemeContext", () => ({
@@ -37,6 +37,11 @@ vi.mock("@porsche-design-system/components-react/ssr", () => ({
   ),
   PText: ({ children, ...rest }: ComponentProps<"span">) => (
     <span data-testid="p-text" {...rest}>
+      {children}
+    </span>
+  ),
+  PTag: ({ children, ...rest }: ComponentProps<"span">) => (
+    <span data-testid="p-tag" {...rest}>
       {children}
     </span>
   ),
@@ -112,13 +117,57 @@ describe("MobileSegmentNav", () => {
     },
   ];
 
+  const rings: Ring[] = [
+    { id: "adopt", title: "Adopt", description: "" },
+    { id: "trial", title: "Trial", description: "" },
+    { id: "assess", title: "Assess", description: "" },
+    { id: "hold", title: "Hold", description: "" },
+  ];
+
+  const items: Item[] = [
+    {
+      id: "item-1",
+      title: "Item 1",
+      ring: "adopt",
+      segment: "languages-and-frameworks",
+      flag: Flag.Default,
+      featured: true,
+    } as Item,
+    {
+      id: "item-2",
+      title: "Item 2",
+      ring: "adopt",
+      segment: "languages-and-frameworks",
+      flag: Flag.Default,
+      featured: true,
+    } as Item,
+    {
+      id: "item-3",
+      title: "Item 3",
+      ring: "trial",
+      segment: "languages-and-frameworks",
+      flag: Flag.Default,
+      featured: true,
+    } as Item,
+    {
+      id: "item-4",
+      title: "Item 4",
+      ring: "hold",
+      segment: "tools",
+      flag: Flag.Default,
+      featured: true,
+    } as Item,
+  ];
+
   beforeEach(() => {
     mockUseTheme.mockReset();
     mockUseTheme.mockReturnValue(makeTheme());
   });
 
   it("renders a nav element with accessible label", () => {
-    render(<MobileSegmentNav segments={segments} />);
+    render(
+      <MobileSegmentNav segments={segments} items={items} rings={rings} />,
+    );
 
     expect(
       screen.getByRole("navigation", { name: "Segments" }),
@@ -126,14 +175,18 @@ describe("MobileSegmentNav", () => {
   });
 
   it("renders a link tile for each segment", () => {
-    render(<MobileSegmentNav segments={segments} />);
+    render(
+      <MobileSegmentNav segments={segments} items={items} rings={rings} />,
+    );
 
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(4);
   });
 
   it("links to the correct segment pages", () => {
-    render(<MobileSegmentNav segments={segments} />);
+    render(
+      <MobileSegmentNav segments={segments} items={items} rings={rings} />,
+    );
 
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute("href", "/base/languages-and-frameworks");
@@ -143,7 +196,9 @@ describe("MobileSegmentNav", () => {
   });
 
   it("passes segment title as description", () => {
-    render(<MobileSegmentNav segments={segments} />);
+    render(
+      <MobileSegmentNav segments={segments} items={items} rings={rings} />,
+    );
 
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute(
@@ -154,14 +209,44 @@ describe("MobileSegmentNav", () => {
   });
 
   it("renders a color swatch with the segment color", () => {
-    const { container } = render(<MobileSegmentNav segments={[segments[0]]} />);
+    const { container } = render(
+      <MobileSegmentNav segments={[segments[0]]} items={items} rings={rings} />,
+    );
 
     const swatch = container.querySelector("[style]");
     expect(swatch).toHaveStyle({ backgroundColor: "#4A9E7E" });
   });
 
+  it("renders a tag per ring with non-zero count for each segment", () => {
+    render(
+      <MobileSegmentNav segments={[segments[0]]} items={items} rings={rings} />,
+    );
+
+    const tags = screen.getAllByTestId("p-tag");
+    expect(tags).toHaveLength(2);
+    expect(tags[0]).toHaveTextContent("Adopt 2");
+    expect(tags[1]).toHaveTextContent("Trial 1");
+  });
+
+  it("omits tags for rings with zero items", () => {
+    render(
+      <MobileSegmentNav segments={[segments[1]]} items={items} rings={rings} />,
+    );
+
+    expect(screen.queryAllByTestId("p-tag")).toHaveLength(0);
+  });
+
+  it("omits tags for rings with zero items", () => {
+    render(
+      <MobileSegmentNav segments={[segments[1]]} items={items} rings={rings} />,
+    );
+
+    // segment "methods-and-patterns" has no items
+    expect(screen.queryAllByTestId("p-tag")).toHaveLength(0);
+  });
+
   it("renders nothing when segments array is empty", () => {
-    render(<MobileSegmentNav segments={[]} />);
+    render(<MobileSegmentNav segments={[]} items={items} rings={rings} />);
 
     const nav = screen.getByRole("navigation", { name: "Segments" });
     expect(nav.children).toHaveLength(0);

--- a/packages/techradar/src/components/SpotlightSearch/SpotlightSearch.module.scss
+++ b/packages/techradar/src/components/SpotlightSearch/SpotlightSearch.module.scss
@@ -352,6 +352,74 @@
   white-space: nowrap;
 }
 
+.mobileClose {
+  display: none;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+
+  &:hover {
+    background: color-mix(in oklch, var(--foreground) 8%, transparent);
+    border-color: var(--highlight);
+    color: var(--foreground);
+  }
+
+  &:active {
+    background: color-mix(in oklch, var(--foreground) 12%, transparent);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--highlight);
+  }
+}
+
+.scopeChip {
+  display: none;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 4px $pds-spacing-static-small;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text);
+  cursor: pointer;
+  font-family: inherit;
+  @include pds-text-x-small;
+  font-weight: $pds-font-weight-bold;
+
+  &:hover {
+    color: var(--foreground);
+    border-color: var(--highlight);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--highlight);
+  }
+
+  &[aria-pressed="true"] {
+    background: color-mix(in oklch, var(--highlight) 18%, transparent);
+    border-color: var(--highlight);
+    color: var(--highlight);
+  }
+}
+
 .footer {
   display: flex;
   flex-wrap: wrap;
@@ -459,5 +527,45 @@
     top: 5vh;
     max-height: 90vh;
     width: calc(100vw - #{$pds-spacing-static-medium});
+  }
+
+  // Hide keyboard hints — irrelevant on touch devices.
+  .itemHotkey,
+  .footer {
+    display: none;
+  }
+
+  // Replace the inline ACTIONS badge with the interactive scope chip.
+  .modeChip {
+    display: none;
+  }
+
+  // Show the tappable Close button and inline Actions chip in the input bar.
+  .mobileClose {
+    display: inline-flex;
+  }
+
+  .scopeChip {
+    display: inline-flex;
+  }
+
+  // Stack title above meta so the title (most important) gets the full
+  // row width instead of being truncated by the meta text. The aside
+  // (action arrow, tags) stays on the right of the row.
+  .itemMain {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  .itemTitle {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+  }
+
+  .itemAside {
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
 }

--- a/packages/techradar/src/components/SpotlightSearch/SpotlightSearch.tsx
+++ b/packages/techradar/src/components/SpotlightSearch/SpotlightSearch.tsx
@@ -414,8 +414,31 @@ export function SpotlightSearch() {
             placeholder={inputPlaceholder}
             className={styles.input}
           />
+          {!activeParent && (
+            <button
+              type="button"
+              className={styles.scopeChip}
+              onClick={() => {
+                if (isCommandMode) {
+                  setQuery("");
+                } else {
+                  setQuery(COMMAND_PREFIX);
+                }
+              }}
+              aria-pressed={isCommandMode}
+            >
+              Actions
+            </button>
+          )}
+          <button
+            type="button"
+            className={cn(styles.iconButton, styles.mobileClose)}
+            onClick={close}
+            aria-label="Close search"
+          >
+            <PIcon name="close" size="small" aria-hidden="true" />
+          </button>
         </div>
-
         <Command.List className={styles.list}>
           <div
             key={activePage ?? "root"}
@@ -499,7 +522,6 @@ export function SpotlightSearch() {
             )}
           </div>
         </Command.List>
-
         <div className={styles.footer}>
           <span>
             <kbd className={styles.kbdSmall}>↑</kbd>

--- a/packages/techradar/src/components/SpotlightSearch/__tests__/SpotlightSearch.test.tsx
+++ b/packages/techradar/src/components/SpotlightSearch/__tests__/SpotlightSearch.test.tsx
@@ -515,4 +515,56 @@ describe("SpotlightSearch", () => {
     await user.click(screen.getByText("Mode: Light"));
     expect(setModeMock).toHaveBeenCalledWith("light");
   });
+
+  it("renders an Actions scope chip that toggles command mode", async () => {
+    const user = userEvent.setup();
+    render(<SpotlightSearch />);
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    const chip = await screen.findByRole("button", { name: "Actions" });
+    expect(chip).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(chip);
+    expect(chip).toHaveAttribute("aria-pressed", "true");
+    expect(
+      (await screen.findByRole("combobox")) as HTMLInputElement,
+    ).toHaveValue(">");
+
+    await user.click(chip);
+    expect(chip).toHaveAttribute("aria-pressed", "false");
+    expect(
+      (await screen.findByRole("combobox")) as HTMLInputElement,
+    ).toHaveValue("");
+  });
+
+  it("hides the scope chip while inside an action submenu", async () => {
+    const user = userEvent.setup();
+    render(<SpotlightSearch />);
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    const input = await screen.findByRole("combobox");
+    await user.type(input, ">");
+    await user.click(screen.getByText("Select Theme"));
+
+    // Inside submenu: the .backChip handles back navigation, the scope chip
+    // is hidden so we don't have two ways to leave the actions view.
+    expect(
+      screen.queryByRole("button", { name: "Actions" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a Close search button that closes the dialog", async () => {
+    const user = userEvent.setup();
+    render(<SpotlightSearch />);
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    expect(await screen.findByRole("combobox")).toBeInTheDocument();
+
+    const closeButton = screen.getByRole("button", { name: "Close search" });
+    await user.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/techradar/src/pages/index.tsx
+++ b/packages/techradar/src/pages/index.tsx
@@ -31,7 +31,7 @@ const Home: CustomPage = () => {
 
       {getToggle("showChart") && (
         <>
-          <MobileSegmentNav segments={segments} />
+          <MobileSegmentNav segments={segments} items={items} rings={rings} />
           <div className={styles.desktopRadar}>
             <Radar
               size={chartConfig.size}


### PR DESCRIPTION
## Summary
- Stack MobileSegmentNav showcase tiles one per row under 480px, switch to 16/9 ratio, widen horizontal margin and gap, and surface per-ring item counts as tags inside each tile
- Make SpotlightSearch usable on touch devices: inline tappable 'Actions' chip toggling command mode, dedicated Close (×) button with hover state, hide keyboard-only hint badges and footer kbd row, stack item title above meta while keeping action arrow on the right
- 566/566 tests pass; lint and typecheck clean