### PR TITLE
fix(techradar): exclude recordDemo.ts from package typecheck

### DIFF
--- a/packages/techradar/tsconfig.dev.json
+++ b/packages/techradar/tsconfig.dev.json
@@ -7,5 +7,10 @@
     ".next-dev/types/**/*.ts",
     ".next-dev/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", ".next", ".next-dev/cache"]
+  "exclude": [
+    "node_modules",
+    ".next",
+    ".next-dev/cache",
+    "scripts/recordDemo.ts"
+  ]
 }

--- a/packages/techradar/tsconfig.json
+++ b/packages/techradar/tsconfig.json
@@ -29,5 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "scripts/recordDemo.ts"]
 }


### PR DESCRIPTION
## Summary

`pnpm run typecheck` is red on `main`. The package-root `tsconfig.json` includes `scripts/recordDemo.ts`, which imports `playwright`. Playwright is deliberately not a devDependency (the recorder is an ad-hoc utility that also depends on system binaries `ffmpeg` and `img2webp` per the precedent set in ADR-0006 / ADR-0011), so type-checking can never resolve it. tsc fails with:

```
scripts/recordDemo.ts(31,37): error TS2307: Cannot find module 'playwright' or its corresponding type declarations.
scripts/recordDemo.ts(136,24): error TS7006: Parameter 't' implicitly has an 'any' type.
```

The shadow tsconfig used during consumer builds (`bin/sanitizeShadowTsconfig.ts`) already excludes `scripts/record*.ts` for exactly this reason. This PR mirrors that intent in the package-local `tsconfig.json` (and `tsconfig.dev.json`, since TypeScript's `extends` does not merge the `exclude` array) so that maintainer `pnpm run typecheck` matches the consumer-build assumption.

## Changes

- `packages/techradar/tsconfig.json`: add `scripts/recordDemo.ts` to `exclude`.
- `packages/techradar/tsconfig.dev.json`: same exclusion (Biome reformatted the array onto multiple lines per the 80-char width rule).

## Verification

Full local harness green:

- `pnpm run lint` — clean (2 pre-existing infos in unrelated files: Biome version mismatch, useless switch case in `packages/create-techradar/src/packageManager.ts`)
- `pnpm run typecheck` — passes
- `pnpm run test` — 632 passed
- `pnpm run check:arch` — passes
- `pnpm run check:sec` — passes
- `pnpm run check:quality` — passes (coverage 84.11% statements)
- `pnpm run check:a11y` — passes
- `pnpm run build` — passes
- `pnpm run check:build` — passes (bundle budget OK, +0.14% growth)

## Notes

This is a pre-existing breakage on `main` and is being fixed as a standalone PR so a follow-up skill PR (`feat/prepare-pr-skill`) can land on top of a green base.