### PR TITLE
fix(create-techradar): approve framework build scripts in scaffolded apps

### DIFF
--- a/packages/create-techradar/src/index.ts
+++ b/packages/create-techradar/src/index.ts
@@ -54,7 +54,7 @@ export async function runCreateTechradar(
       frameworkPackage: FRAMEWORK_PACKAGE,
       frameworkVersionRange: versionRange,
     });
-    writePnpmWorkspace(target.absolutePath);
+    writePnpmWorkspace(target.absolutePath, FRAMEWORK_PACKAGE);
     writeReadme(target.absolutePath, target.projectName);
 
     consola.start(`Installing dependencies with ${pm}`);

--- a/packages/create-techradar/src/scaffold.test.ts
+++ b/packages/create-techradar/src/scaffold.test.ts
@@ -173,7 +173,7 @@ describe("scaffold helpers", () => {
       assert.deepEqual(
         (json.pnpm as { onlyBuiltDependencies: string[] })
           .onlyBuiltDependencies,
-        ["@parcel/watcher", "esbuild", "sharp"],
+        ["@x/y", "@parcel/watcher", "esbuild", "sharp"],
       );
     });
   });
@@ -203,20 +203,24 @@ describe("scaffold helpers", () => {
   });
 
   describe("buildPnpmWorkspace", () => {
+    it("approves the framework package", () => {
+      assert.match(buildPnpmWorkspace("@x/y"), /"@x\/y": true/);
+    });
+
     it("approves @parcel/watcher", () => {
-      assert.match(buildPnpmWorkspace(), /"@parcel\/watcher": true/);
+      assert.match(buildPnpmWorkspace("@x/y"), /"@parcel\/watcher": true/);
     });
 
     it("approves esbuild", () => {
-      assert.match(buildPnpmWorkspace(), /esbuild: true/);
+      assert.match(buildPnpmWorkspace("@x/y"), /esbuild: true/);
     });
 
     it("approves sharp", () => {
-      assert.match(buildPnpmWorkspace(), /sharp: true/);
+      assert.match(buildPnpmWorkspace("@x/y"), /sharp: true/);
     });
 
     it("ends with a trailing newline", () => {
-      assert.ok(buildPnpmWorkspace().endsWith("\n"));
+      assert.ok(buildPnpmWorkspace("@x/y").endsWith("\n"));
     });
   });
 
@@ -240,8 +244,9 @@ describe("scaffold helpers", () => {
     });
 
     it("writePnpmWorkspace writes a valid pnpm-workspace.yaml", () => {
-      writePnpmWorkspace(workspace);
+      writePnpmWorkspace(workspace, "@x/y");
       const raw = readFileSync(join(workspace, "pnpm-workspace.yaml"), "utf8");
+      assert.match(raw, /"@x\/y": true/);
       assert.match(raw, /"@parcel\/watcher": true/);
       assert.match(raw, /esbuild: true/);
       assert.match(raw, /sharp: true/);

--- a/packages/create-techradar/src/scaffold.ts
+++ b/packages/create-techradar/src/scaffold.ts
@@ -76,10 +76,17 @@ export function buildPackageJson(
       [inputs.frameworkPackage]: inputs.frameworkVersionRange,
     },
     pnpm: {
-      // pnpm v10+ blocks native addon build scripts by default.
-      // Approve the packages that Next.js requires so `pnpm install` succeeds
-      // out of the box without manual `pnpm approve-builds`.
-      onlyBuiltDependencies: ["@parcel/watcher", "esbuild", "sharp"],
+      // pnpm v10+ blocks build scripts by default — both native addon installs
+      // and lifecycle scripts of external deps. Approve the framework (whose
+      // postinstall bootstraps `data/data.json`) plus the native-addon trio
+      // Next.js requires, so `pnpm install` succeeds out of the box without
+      // manual `pnpm approve-builds`.
+      onlyBuiltDependencies: [
+        inputs.frameworkPackage,
+        "@parcel/watcher",
+        "esbuild",
+        "sharp",
+      ],
     },
   };
 }
@@ -115,12 +122,13 @@ export function writeReadme(targetDir: string, projectName: string): void {
   );
 }
 
-export function buildPnpmWorkspace(): string {
+export function buildPnpmWorkspace(frameworkPackage: string): string {
   return [
     "# pnpm v10.26+ reads build-script approvals from this file.",
-    "# The three packages below are native addons required by Next.js.",
+    "# Approves the framework's postinstall plus the native addons Next.js needs.",
     "# There are no workspace member packages — this is a standalone project.",
     "allowBuilds:",
+    `  "${frameworkPackage}": true`,
     '  "@parcel/watcher": true',
     "  esbuild: true",
     "  sharp: true",
@@ -128,10 +136,13 @@ export function buildPnpmWorkspace(): string {
   ].join("\n");
 }
 
-export function writePnpmWorkspace(targetDir: string): void {
+export function writePnpmWorkspace(
+  targetDir: string,
+  frameworkPackage: string,
+): void {
   writeFileSync(
     resolve(targetDir, "pnpm-workspace.yaml"),
-    buildPnpmWorkspace(),
+    buildPnpmWorkspace(frameworkPackage),
     "utf8",
   );
 }


### PR DESCRIPTION
## Summary

Every dependabot PR (#76–#90) and `main`'s scaffolder-e2e job is currently red on a single failure:

```
ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: @porscheofficial/porschedigital-technology-radar@2.1.0
```

Root cause: framework v2.1.0 added a `postinstall` lifecycle script. pnpm 10 refuses to run lifecycle scripts of external deps unless explicitly allowlisted, so scaffolded apps (and the e2e job that simulates one) fail on first install. This is unrelated to dependabot's diffs — any PR opened today fails identically — and would block real consumers running `pnpm create techradar` today.

This PR fixes the scaffolder so generated apps approve the framework's build scripts out of the box.

## Changes

- `packages/create-techradar/src/scaffold.ts`
  - Prepend `inputs.frameworkPackage` to the scaffolded `package.json` `pnpm.onlyBuiltDependencies` allowlist (covers older pnpm 10 clients).
  - Add `frameworkPackage` parameter to `buildPnpmWorkspace`/`writePnpmWorkspace` and emit it in the `pnpm-workspace.yaml` `allowBuilds` map (covers pnpm 10.26+ which prefers the workspace file).
- `packages/create-techradar/src/index.ts` — pass `FRAMEWORK_PACKAGE` through to `writePnpmWorkspace`.
- `packages/create-techradar/src/scaffold.test.ts` — assertions updated for both helpers; new dedicated "approves the framework package" cases. 75/75 tests pass.

The framework-side `postinstall` is intentionally **not** removed — it is load-bearing for the `bootstrap-fresh-clone` CI job, which runs `pnpm install` followed immediately by `pnpm --filter ... test` with no intervening `build:data` step.

## Why allowlist on the scaffolder side rather than dropping `postinstall`

- Dropping it would break `bootstrap-fresh-clone` CI (confirmed: previous revision of this PR did exactly that).
- Even if we re-routed CI, v2.1.0 is already published. Real consumers running `pnpm create techradar` today would still hit the gate. The scaffolder fix benefits **all** consumers immediately, including consumers of the already-published v2.1.0 release.
- Allowlist additions are forward-compatible: future framework versions can rely on the same approval without churn.

## Verification

Local harness (from repo root):

| step | result |
| --- | --- |
| `pnpm run lint` | ✅ (2 pre-existing infos, none introduced here) |
| `pnpm run typecheck` | ✅ |
| `pnpm run test` | ✅ 632 framework + 75 scaffolder tests |
| `pnpm run check:arch` | ✅ |
| `pnpm run check:sec` | ⚠️ 15 pre-existing CVEs in `next@16.2.4` / `fast-uri@3.1.0` — identical on `main`, no lockfile changes in this PR. Fixing them is exactly what the now-unblocked dependabot PRs do. |
| `pnpm run check:quality` | ✅ |
| `pnpm run check:a11y` | ✅ |
| `pnpm run build` + `pnpm run check:build` | ✅ |

## Expected CI impact

Once this lands on `main`, the scaffolder-e2e check (the sole failing check on every dependabot PR) goes green for both:

- subsequent PRs opened against `main`
- existing dependabot PRs after they rebase / refresh

The 15 dependabot PRs (#76–#90) will then unblock.

## Notes for reviewers

- `packages/techradar/bin/techradar.ts:215` still does `delete pkg.scripts.postinstall` in the init flow — harmless dead code given v2.1.0's postinstall stays in place. Worth a follow-up cleanup, intentionally out of scope here.
- `cspell-words.txt:445` keeps `postinstall` (still referenced in ADR-0019, ADR-0021, bin comments).
