### PR TITLE
feat(techradar): richer demo recorder with synthetic cursor and 7 scenes

### DIFF
--- a/packages/techradar/scripts/recordDemo.ts
+++ b/packages/techradar/scripts/recordDemo.ts
@@ -1,11 +1,24 @@
 // recordDemo.ts — generate the animated WebP shown in the repo README.
 //
-// Reproducible recording of the live UI: theming + key pages. The script
-// boots a static file server against the already-built `out/` directory,
-// drives a headless Chromium through a declarative scene list with
-// Playwright, captures a WebM via Playwright's recordVideo, then assembles
-// the animated WebP from PNG frames using ffmpeg (frame extraction) and
-// img2webp from libwebp (animation muxing).
+// Reproducible recording of the live UI. The script boots a static file
+// server against the already-built `out/` directory, drives a headless
+// Chromium through a declarative scene list with Playwright, captures a
+// WebM via Playwright's recordVideo, then assembles the animated WebP from
+// PNG frames using ffmpeg (frame extraction) and img2webp from libwebp
+// (animation muxing).
+//
+// Two overlays are injected client-side via addInitScript so they survive
+// navigation and reload:
+//
+//   1. A synthetic cursor — Playwright's recordVideo does NOT render the
+//      real mouse pointer, so without this every interaction looks like the
+//      page is operating itself. The overlay is a DOM element animated via
+//      CSS transitions; its position is driven from the recorder, and the
+//      real Playwright mouse/click events still fire on the underlying
+//      elements (they just happen to align spatially).
+//
+//   2. A small caption chyron at the bottom-left, deliberately low-key so
+//      the product breathes through.
 //
 // Determinism levers:
 // - Fixed viewport, deviceScaleFactor, locale, timezone, colorScheme.
@@ -28,72 +41,145 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { consola } from "consola";
-import { chromium, type Page } from "playwright";
+import { chromium, type Locator, type Page } from "playwright";
 
 const execFileAsync = promisify(execFile);
 const FRAME_RATE = 12;
 const FRAME_DURATION_MS = Math.round(1000 / FRAME_RATE);
-const TARGET_WIDTH = 1024;
-const WEBP_QUALITY = 75;
+const TARGET_WIDTH = 800;
+const WEBP_QUALITY = 70;
 
 const PORT = 4319;
 const HOST = `http://127.0.0.1:${PORT}`;
 const VIEWPORT = { width: 1440, height: 1040 } as const;
 
-// Injected via addInitScript so the caption survives navigation + reload.
-// The script appends a fixed overlay on DOMContentLoaded and exposes
-// `window.__setDemoCaption(text)` for the recorder to drive per-scene labels.
-const CAPTION_INIT_SCRIPT = `
+// Injected via addInitScript. Provides:
+//   window.__demoCursorSet(x, y)   — animate cursor to viewport coords
+//   window.__demoCursorShow(bool)  — fade cursor in/out
+//   window.__demoCursorPulse()     — click ripple animation
+//   window.__demoCaption(text)     — show / hide caption (empty = hide)
+//
+// The cursor itself is purely cosmetic — Playwright's own mouse events are
+// what drive the underlying elements. We just animate a DOM overlay to
+// follow along so viewers can see intent.
+const OVERLAY_INIT_SCRIPT = `
 (() => {
   try {
     localStorage.setItem("radar-disclaimer-dismissed", "1");
   } catch {}
-  const ID = "__demo_caption__";
-  const ensure = () => {
-    let el = document.getElementById(ID);
+
+  const CURSOR_ID = "__demo_cursor__";
+  const CAPTION_ID = "__demo_caption__";
+  const STYLE_ID = "__demo_overlay_styles__";
+
+  const ensureStyle = () => {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = [
+      "#" + CURSOR_ID + " {",
+      "  position: fixed; left: 0; top: 0;",
+      "  width: 22px; height: 22px; margin: -11px 0 0 -11px;",
+      "  border-radius: 50%;",
+      "  background: radial-gradient(circle at 35% 32%, #ffffff 0%, #f4f6fb 55%, #d3dae5 100%);",
+      "  box-shadow: 0 6px 18px rgba(0,0,0,0.42), 0 0 0 1.5px rgba(0,0,0,0.28);",
+      "  pointer-events: none; z-index: 2147483647;",
+      "  opacity: 0;",
+      "  transform: translate3d(0,0,0);",
+      "  transition: opacity 260ms ease, transform 720ms cubic-bezier(.22,.61,.36,1);",
+      "  will-change: transform;",
+      "}",
+      "#" + CURSOR_ID + ".visible { opacity: 1; }",
+      "#" + CURSOR_ID + "::after {",
+      "  content: \\"\\"; position: absolute; inset: -8px;",
+      "  border-radius: 50%; border: 2px solid rgba(255,255,255,0.55);",
+      "  opacity: 0; transform: scale(0.55);",
+      "  transition: opacity 360ms ease, transform 360ms cubic-bezier(.22,.61,.36,1);",
+      "}",
+      "#" + CURSOR_ID + ".clicking::after {",
+      "  opacity: 1; transform: scale(1.85);",
+      "  transition: opacity 0ms, transform 0ms;",
+      "}",
+      "#" + CAPTION_ID + " {",
+      "  position: fixed; left: 36px; bottom: 36px;",
+      "  padding: 10px 18px; border-radius: 999px;",
+      "  background: rgba(15,15,20,0.78); color: #fff;",
+      "  font: 500 16px/1.3 -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, system-ui, sans-serif;",
+      "  letter-spacing: 0.01em;",
+      "  border: 1px solid rgba(255,255,255,0.08);",
+      "  box-shadow: 0 10px 28px rgba(0,0,0,0.36);",
+      "  backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);",
+      "  pointer-events: none; max-width: 70vw;",
+      "  opacity: 0; transform: translateY(8px);",
+      "  transition: opacity 260ms ease, transform 260ms ease;",
+      "  z-index: 2147483646;",
+      "}",
+      "#" + CAPTION_ID + ".visible { opacity: 1; transform: translateY(0); }",
+    ].join("\\n");
+    document.head.appendChild(style);
+  };
+
+  const ensureCursor = () => {
+    let el = document.getElementById(CURSOR_ID);
     if (!el) {
       el = document.createElement("div");
-      el.id = ID;
-      el.style.cssText = [
-        "position:fixed",
-        "left:50%",
-        "bottom:36px",
-        "transform:translateX(-50%)",
-        "z-index:2147483647",
-        "padding:16px 32px",
-        "border-radius:18px",
-        "background:linear-gradient(135deg,rgba(15,15,20,0.92),rgba(40,40,55,0.92))",
-        "color:#fff",
-        "font:700 26px/1.25 -apple-system,BlinkMacSystemFont,'Segoe UI',Inter,system-ui,sans-serif",
-        "letter-spacing:0.005em",
-        "border:1px solid rgba(255,255,255,0.14)",
-        "box-shadow:0 12px 40px rgba(0,0,0,0.45),0 0 0 1px rgba(255,255,255,0.05) inset",
-        "backdrop-filter:blur(8px)",
-        "-webkit-backdrop-filter:blur(8px)",
-        "pointer-events:none",
-        "max-width:82vw",
-        "text-align:center",
-        "transition:opacity 220ms ease,transform 220ms ease",
-        "opacity:0",
-      ].join(";");
+      el.id = CURSOR_ID;
       document.body.appendChild(el);
     }
     return el;
   };
-  const apply = () => ensure();
+
+  const ensureCaption = () => {
+    let el = document.getElementById(CAPTION_ID);
+    if (!el) {
+      el = document.createElement("div");
+      el.id = CAPTION_ID;
+      document.body.appendChild(el);
+    }
+    return el;
+  };
+
+  // Public API entry points are wrapped in apply() so styles + DOM nodes
+  // are guaranteed before the first call, even if the recorder evaluates
+  // an overlay function in the narrow window between addInitScript and
+  // DOMContentLoaded firing.
+  const apply = () => {
+    ensureStyle();
+    ensureCursor();
+    ensureCaption();
+  };
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", apply, { once: true });
   } else {
     apply();
   }
-  window.__setDemoCaption = (text) => {
-    const el = ensure();
+
+  window.__demoCursorSet = (x, y) => {
+    apply();
+    const el = ensureCursor();
+    el.style.transform = "translate3d(" + x + "px, " + y + "px, 0)";
+  };
+  window.__demoCursorShow = (show) => {
+    apply();
+    ensureCursor().classList.toggle("visible", !!show);
+  };
+  window.__demoCursorPulse = () => {
+    apply();
+    const el = ensureCursor();
+    el.classList.remove("clicking");
+    void el.offsetWidth;
+    el.classList.add("clicking");
+    setTimeout(() => el.classList.remove("clicking"), 360);
+  };
+  window.__demoCaption = (text) => {
+    apply();
+    const el = ensureCaption();
     if (!text) {
-      el.style.opacity = "0";
+      el.classList.remove("visible");
       return;
     }
     el.textContent = text;
-    el.style.opacity = "1";
+    el.classList.add("visible");
   };
 })();
 `;
@@ -125,95 +211,285 @@ const MIME: Record<string, string> = {
   ".xml": "application/xml",
 };
 
+interface DemoWindow {
+  __demoCursorSet?: (x: number, y: number) => void;
+  __demoCursorShow?: (show: boolean) => void;
+  __demoCursorPulse?: () => void;
+  __demoCaption?: (text: string) => void;
+}
+
+interface SceneContext {
+  page: Page;
+}
+
 interface Scene {
   description: string;
-  caption: string;
-  action: (page: Page) => Promise<void>;
-  hold: number;
+  run: (ctx: SceneContext) => Promise<void>;
 }
+
+// --- overlay helpers -------------------------------------------------------
 
 async function setCaption(page: Page, text: string): Promise<void> {
   await page.evaluate((t) => {
-    const w = window as unknown as { __setDemoCaption?: (s: string) => void };
-    w.__setDemoCaption?.(t);
+    (window as unknown as DemoWindow).__demoCaption?.(t);
   }, text);
 }
 
+async function showCursor(page: Page, show: boolean): Promise<void> {
+  await page.evaluate((s) => {
+    (window as unknown as DemoWindow).__demoCursorShow?.(s);
+  }, show);
+}
+
+async function placeCursor(page: Page, x: number, y: number): Promise<void> {
+  await page.evaluate(
+    ([px, py]) => {
+      (window as unknown as DemoWindow).__demoCursorSet?.(px, py);
+    },
+    [x, y],
+  );
+}
+
+async function pulseCursor(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as DemoWindow).__demoCursorPulse?.();
+  });
+}
+
+async function moveCursorTo(
+  page: Page,
+  target: Locator,
+  settleMs = 760,
+): Promise<{ x: number; y: number }> {
+  const box = await target.boundingBox();
+  if (!box) {
+    throw new Error("moveCursorTo: target has no bounding box");
+  }
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  await placeCursor(page, x, y);
+  await page.waitForTimeout(settleMs);
+  return { x, y };
+}
+
+async function cursorClick(page: Page, target: Locator): Promise<void> {
+  await moveCursorTo(page, target);
+  await pulseCursor(page);
+  await page.waitForTimeout(140);
+  await target.click();
+}
+
+// --- scenes ----------------------------------------------------------------
+
 const scenes: Scene[] = [
   {
-    description: "Land on the radar",
-    caption: "The Tech Radar — adopt · trial · assess · hold",
-    action: async (page) => {
+    description: "Cold open — Spotlight search",
+    run: async ({ page }) => {
       await page.goto(`${HOST}/`, { waitUntil: "networkidle" });
-    },
-    hold: 2600,
-  },
-  {
-    description: "Open the Tools segment",
-    caption: "Segment view — zoom into one quadrant",
-    action: async (page) => {
-      await page.goto(`${HOST}/tools/`, { waitUntil: "networkidle" });
-    },
-    hold: 2600,
-  },
-  {
-    description: "Open the Copilot item detail",
-    caption: "Item detail — rationale, history, links",
-    action: async (page) => {
-      await page.goto(`${HOST}/tools/copilot/`, { waitUntil: "networkidle" });
-    },
-    hold: 2800,
-  },
-  {
-    description: "Back to the radar",
-    caption: "Theming — pick a palette, then a mode",
-    action: async (page) => {
-      await page.goto(`${HOST}/`, { waitUntil: "networkidle" });
-    },
-    hold: 1600,
-  },
-  {
-    description: "Switch theme to synthwave",
-    caption: "Theme: Synthwave",
-    action: async (page) => {
+      await showCursor(page, false);
+      await page.waitForTimeout(700);
+
+      const trigger = page
+        .getByRole("button", { name: "Search & actions" })
+        .first();
+      // Pre-position the cursor a bit away from the trigger so the move
+      // is visible when we fade it in.
+      const box = await trigger.boundingBox();
+      if (box) {
+        await placeCursor(
+          page,
+          Math.max(40, box.x - 180),
+          box.y + box.height / 2 + 60,
+        );
+      }
+      await showCursor(page, true);
+      await setCaption(page, "Search anything — press \u2318 K");
+      await page.waitForTimeout(420);
+
+      await cursorClick(page, trigger);
+      await page
+        .getByRole("dialog")
+        .waitFor({ state: "visible", timeout: 4000 });
+      await page.waitForTimeout(260);
+
+      // cmdk auto-focuses Command.Input on dialog open.
+      await page.keyboard.type("kub", { delay: 110 });
+      await page.waitForTimeout(520);
+      await pulseCursor(page);
+      await page.keyboard.press("Enter");
+
+      await page.waitForLoadState("networkidle");
+      await showCursor(page, false);
+      await setCaption(page, "Every technology gets its own page");
+      await page.waitForTimeout(900);
       await page.evaluate(() => {
-        localStorage.setItem("techradar-theme", "synthwave");
+        window.scrollTo({ top: 420, behavior: "smooth" });
       });
-      await page.reload({ waitUntil: "networkidle" });
+      await page.waitForTimeout(2200);
     },
-    hold: 2400,
   },
   {
-    description: "Switch to light mode",
-    caption: "Light mode",
-    action: async (page) => {
-      await page
-        .getByRole("button", { name: /Theme mode: Light/i })
-        .first()
-        .click();
+    description: "Hover and open a blip",
+    run: async ({ page }) => {
+      await page.goto(`${HOST}/`, { waitUntil: "networkidle" });
+      await page.waitForTimeout(450);
+
+      const blip = page.locator('[data-item-id="react"]').first();
+      await blip.waitFor({ state: "visible", timeout: 4000 });
+
+      const box = await blip.boundingBox();
+      if (box) {
+        await placeCursor(page, box.x - 220, box.y + 140);
+      }
+      await showCursor(page, true);
+      await setCaption(page, "Hover a blip to peek — click to dive in");
+      await page.waitForTimeout(360);
+
+      const { x, y } = await moveCursorTo(page, blip);
+      // Drive the real mouse too so any hover-bound CSS / JS engages.
+      await page.mouse.move(x, y);
+      await page.waitForTimeout(900);
+
+      await pulseCursor(page);
+      await page.waitForTimeout(120);
+      await blip.click();
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(900);
     },
-    hold: 2000,
   },
   {
-    description: "Switch back to dark mode",
-    caption: "Dark mode",
-    action: async (page) => {
-      await page
-        .getByRole("button", { name: /Theme mode: Dark/i })
-        .first()
-        .click();
+    description: "Filter by tag",
+    run: async ({ page }) => {
+      await page.goto(`${HOST}/`, { waitUntil: "networkidle" });
+      await page.waitForTimeout(420);
+
+      const filterRegion = page.getByRole("region", { name: "Filter radar" });
+      await filterRegion.waitFor({ state: "visible", timeout: 4000 });
+      const viewportHeight = page.viewportSize()?.height ?? 1040;
+      const filterDocTop = await filterRegion.evaluate(
+        (el) => el.getBoundingClientRect().top + window.scrollY,
+      );
+      await page.evaluate(
+        (top) => {
+          window.scrollTo({ top, behavior: "smooth" });
+        },
+        Math.max(0, filterDocTop - viewportHeight * 0.78),
+      );
+      await page.waitForTimeout(700);
+
+      const tagBtn = filterRegion
+        .getByRole("button", { name: /^frontend$/i })
+        .first();
+      const tagBox = await tagBtn.boundingBox();
+      if (tagBox) {
+        await placeCursor(page, tagBox.x - 200, tagBox.y + 90);
+      }
+      await showCursor(page, true);
+      await setCaption(page, "Filter by tag, team, or status");
+      await page.waitForTimeout(360);
+      await cursorClick(page, tagBtn);
+      await page.waitForTimeout(1400);
+
+      await pulseCursor(page);
+      await page.waitForTimeout(120);
+      await tagBtn.click();
+      await page.waitForTimeout(500);
     },
-    hold: 1900,
   },
   {
-    description: "Final hold",
-    caption: "github.com/porscheofficial/porschedigital-technology-radar",
-    action: async () => {
-      // intentionally idle — lets the closing caption breathe
+    description: "Open a segment view",
+    run: async ({ page }) => {
+      await page.goto(`${HOST}/`, { waitUntil: "networkidle" });
+      await page.waitForTimeout(450);
+
+      const segment = page.locator('svg a[href^="/tools"]').first();
+      await segment.waitFor({ state: "visible", timeout: 4000 });
+
+      const box = await segment.boundingBox();
+      if (box) {
+        await placeCursor(page, box.x - 180, box.y + box.height + 80);
+      }
+      await showCursor(page, true);
+      await setCaption(page, "Zoom into a segment to compare its blips");
+      await page.waitForTimeout(360);
+
+      await cursorClick(page, segment);
+      await page.waitForLoadState("networkidle");
+      await showCursor(page, false);
+      await page.waitForTimeout(900);
+      await page.evaluate(() => {
+        window.scrollTo({ top: 320, behavior: "smooth" });
+      });
+      await page.waitForTimeout(1800);
     },
-    hold: 1600,
+  },
+  {
+    description: "Changelog — assessments over time",
+    run: async ({ page }) => {
+      await page.goto(`${HOST}/changelog/`, { waitUntil: "networkidle" });
+      await showCursor(page, false);
+      await setCaption(page, "See how assessments evolved across releases");
+      await page.waitForTimeout(550);
+      await page.evaluate(() => {
+        window.scrollTo({ top: 360, behavior: "smooth" });
+      });
+      await page.waitForTimeout(1500);
+    },
+  },
+  {
+    description: "Theme swap to Synthwave",
+    run: async ({ page }) => {
+      await page.goto(`${HOST}/`, { waitUntil: "networkidle" });
+      await page.waitForTimeout(420);
+
+      const trigger = page
+        .getByRole("button", { name: "Search & actions" })
+        .first();
+      const box = await trigger.boundingBox();
+      if (box) {
+        await placeCursor(
+          page,
+          Math.max(40, box.x - 180),
+          box.y + box.height / 2 + 60,
+        );
+      }
+      await showCursor(page, true);
+      await setCaption(page, "Built-in themes — pick one or build your own");
+      await page.waitForTimeout(380);
+
+      await cursorClick(page, trigger);
+      const dialog = page.getByRole("dialog");
+      await dialog.waitFor({ state: "visible", timeout: 4000 });
+      await page.waitForTimeout(220);
+
+      await page.keyboard.type(">theme", { delay: 90 });
+      await page.waitForTimeout(520);
+      await pulseCursor(page);
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(420);
+
+      await page.keyboard.type("synthwave", { delay: 90 });
+      await page.waitForTimeout(520);
+      await pulseCursor(page);
+      await page.keyboard.press("Enter");
+
+      await page.waitForTimeout(1900);
+    },
+  },
+  {
+    description: "Closing card",
+    run: async ({ page }) => {
+      await showCursor(page, false);
+      await setCaption(
+        page,
+        "github.com/porscheofficial/porschedigital-technology-radar",
+      );
+      await page.waitForTimeout(1600);
+    },
   },
 ];
+
+// --- plumbing --------------------------------------------------------------
 
 async function pathExists(p: string): Promise<boolean> {
   try {
@@ -345,14 +621,12 @@ async function main(): Promise<void> {
       reducedMotion: "no-preference",
       recordVideo: { dir: tmp, size: VIEWPORT },
     });
-    await context.addInitScript(CAPTION_INIT_SCRIPT);
+    await context.addInitScript(OVERLAY_INIT_SCRIPT);
     const page = await context.newPage();
 
     for (const scene of scenes) {
       consola.info(`Scene: ${scene.description}`);
-      await scene.action(page);
-      await setCaption(page, scene.caption);
-      await page.waitForTimeout(scene.hold);
+      await scene.run({ page });
     }
 
     await page.close();


### PR DESCRIPTION
## Summary

Rewrites the README demo recorder into a guided 7-scene product tour with a synthetic cursor and caption overlay, replacing the previous static page-flip animation. The result is a far more inviting README header — visitors see Spotlight search, blip interaction, tag filtering, segment view, changelog, an interactive theme swap to Synthwave, and a closing card with the repo URL — all within ~36s.

## Changes

- `packages/techradar/scripts/recordDemo.ts`: full rewrite of the scene pipeline. New `addInitScript`-injected overlay exposes four `window.__demo*` methods (cursor position/show/pulse and caption set) consumed by procedural Playwright scenes. Cursor is a 22 px radial-gradient circle with smooth `transform` transitions and a click-pulse pseudo-element; caption pill is bottom-left with backdrop blur. Static server, Chromium recording, ffmpeg → img2webp WebP mux unchanged.
- Tightened the filter scene framing so the radar stays dominant in the upper viewport and the footer never enters the frame.
- Downscaled output to 800 px / WebP quality 70 to keep `docs/media/demo.webp` lightweight for GitHub's README rendering (which preview at ~700-900 px wide anyway).
- `docs/media/demo.webp`: regenerated artifact.

## Verification

- Local harness: lint, typecheck, test (632 + 74 pass), check:arch, check:quality (84.11% coverage, cspell clean), check:a11y (36 HTML files, no serious/critical), check:build (bundle 691.2 KB, +0.14%) — all green.
- check:sec: osv-scanner clean (0 vulns); trufflehog skipped locally because this worktree's \`.git\` is a file rather than a directory — CI clones normally so it will run there.
- Frame-by-frame visual verification of each of the 7 scenes via Pillow + manual inspection: cursor + caption render on every interactive scene, theme swap to Synthwave is clearly visible, closing card shows the GitHub URL.

## Notes for reviewers

- The OVERLAY_INIT_SCRIPT injection is a template literal with embedded CSS/JS — the public-API comment block above it documents the four-method contract so callers don't have to read the embedded source.
- Each scene calls \`apply()\` defensively inside the public window methods to close the \`addInitScript\` → DOMContentLoaded race window across \`page.goto()\` boundaries.
- The Spotlight scene types \`>theme\` first to enter cmdk command mode before selecting \`Select Theme\` → submenu, then \`synthwave\`. This mirrors how a user would actually do it via keyboard.