### PR TITLE
fix(techradar): dereference symlinks when copying package to shadow build dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,32 +61,45 @@ jobs:
       - run: pnpm --filter @porscheofficial/porschedigital-technology-radar build
 
   scaffolder-e2e:
-    name: Scaffolder to framework e2e
+    name: Scaffolder to framework e2e (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24, 26]
     steps:
       # Pinned to commit SHA per OpenSSF Scorecard PinnedDependenciesID.
       # See ADR-0017.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
       - run: pnpm install
       - run: pnpm --filter @porscheofficial/porschedigital-technology-radar run build:bin
       - run: pnpm --filter @porscheofficial/create-techradar run build
       - run: pnpm --filter @porscheofficial/create-techradar pack --pack-destination "$RUNNER_TEMP/create-techradar-pack"
+      # Pack the framework into a real tarball and install it via `file:` in
+      # the scaffolded app. This forces pnpm to fetch and unpack the tarball
+      # into its content-addressed `node_modules/.pnpm/` store with the same
+      # symlinked layout a real consumer gets. The previous `link:` form
+      # short-circuited the store (direct directory link) and so could not
+      # reproduce shadow-build bugs that only manifest under that layout —
+      # ADR-0033 documents one such bug shipped to 2.2.0.
+      - run: pnpm --filter @porscheofficial/porschedigital-technology-radar pack --pack-destination "$RUNNER_TEMP/techradar-pack"
       - name: Scaffold app and run full pipeline
         shell: bash
         run: |
           set -euo pipefail
           sandbox="$(mktemp -d "$RUNNER_TEMP/scaffolder-e2e-XXXXXX")"
           cd "$sandbox"
-          export npm_config_user_agent="pnpm/10.29.2 npm/? node/v22.21.1 linux x64"
+          export npm_config_user_agent="pnpm/10.29.2 npm/? node/v${{ matrix.node }}.0.0 linux x64"
           pnpm dlx "$RUNNER_TEMP/create-techradar-pack/"*.tgz test-app --yes
           cd test-app
-          pnpm add "link:$GITHUB_WORKSPACE/packages/techradar"
+          techradar_tarball="$(ls "$RUNNER_TEMP/techradar-pack/"*.tgz | head -n1)"
+          pnpm add "file:${techradar_tarball}"
           node <<'EOF'
           const fs = require("node:fs");
           const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,16 @@ jobs:
           cd test-app
           techradar_tarball="$(ls "$RUNNER_TEMP/techradar-pack/"*.tgz | head -n1)"
           pnpm add "file:${techradar_tarball}"
+          # `create-techradar` fetches the framework from the npm registry at
+          # scaffold time and writes the seed `radar/` content plus
+          # `.markdownlint-cli2.jsonc` from THAT registry copy. The
+          # `pnpm add file:` above only swaps `node_modules/...`, so any fix
+          # to seed content or bundled config in this PR would still be
+          # masked by the already-scaffolded stale copies in CWD. Wipe and
+          # re-scaffold from the local tarball so the e2e actually exercises
+          # what's in this PR. See ADR-0033.
+          rm -rf radar/ .markdownlint-cli2.jsonc
+          pnpm exec techradar init
           node <<'EOF'
           const fs = require("node:fs");
           const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));

--- a/docs/decisions/0033-shadow-dereference-symlinks.md
+++ b/docs/decisions/0033-shadow-dereference-symlinks.md
@@ -114,10 +114,15 @@ the `@/*` alias: they run via Vitest only inside the dev repo (the shadow
 build excludes them via `sanitizeShadowTsconfig()`), and Vitest's resolver
 is configured against the dev-repo `tsconfig.json` independently.
 
-A regression test in `bin/__tests__/shadow-build-symlinks.test.ts`
-table-tests every `scripts/**/*.ts` (excluding `__tests__/`) for absence of
-`from "@/…"` imports, and asserts the `cpSync` call in `bin/techradar.ts`
-still carries `dereference: true`.
+A behavioural regression test in
+`bin/__tests__/copyPackageToBuilder.test.ts` builds a pnpm-shaped tmpdir
+(scoped install symlinking per-entry into a `.pnpm/<name>/` store), runs
+`copyPackageToBuilder()`, and asserts every copied file is a real file
+whose `realpath()` stays inside the builder dir and that nested
+`node_modules/` is filtered out. A second test in
+`bin/__tests__/shadow-build-symlinks.test.ts` table-tests every
+`scripts/**/*.ts` (excluding `__tests__/`) for absence of `from "@/…"`
+imports.
 
 The `.dependency-cruiser.cjs` rule `no-deep-relative-imports` is unaffected:
 it only flags `from: { path: "^src" }`, not `^scripts`, and only blocks
@@ -175,9 +180,43 @@ than enumerating which downstream code paths assume it.
 
 **Followups (not part of this ADR)**
 
-- Consider a sensor that asserts `realpathSync('.techradar/scripts/buildData.ts')`
-  starts with `BUILDER_DIR` after `ensureBuildDir()` runs, as a runtime
-  check complementing the string-match regression test.
+- None outstanding. The behavioural test on `copyPackageToBuilder()`
+  already asserts `realpath()` of copied entries stays inside the builder
+  dir, which subsumes the originally-planned runtime sensor.
+
+## CI gap and closure
+
+The bug shipped in 2.2.0 despite an existing `scaffolder-e2e` job in
+`.github/workflows/ci.yml` because the job had two blind spots that, combined,
+made the failure mode invisible:
+
+1. **`link:` instead of `file:` install.** The job did
+   `pnpm add "link:$GITHUB_WORKSPACE/packages/techradar"`. pnpm treats `link:`
+   as a direct directory link — no tarball, no content-addressed store, no
+   symlinked layout. `ensureBuildDir()` therefore saw real files at the
+   source and `cpSync` produced real files at the destination. The pnpm
+   shape that breaks `realpath()`-based resolution simply never existed in
+   CI.
+2. **Single Node version.** The job pinned `node-version: 22`. The
+   tsx-resolver-vs-CJS-loader interaction documented above only crashes on
+   Node ≥26. Even if the layout had been correct, Node 22 would not have
+   reproduced the failure.
+
+Both gaps are closed in the same change:
+
+- The job now packs the framework with
+  `pnpm --filter @porscheofficial/porschedigital-technology-radar pack` and
+  installs it as `file:<tarball>` in the scaffolded sandbox. pnpm fetches,
+  unpacks into `.pnpm/<name>/`, and produces the same symlinked surface a
+  real consumer gets.
+- The job runs across `node-version: [22, 24, 26]` with `fail-fast: false`,
+  so any future Node-major-induced regression in shadow-build resolution
+  fails CI on the affected version before publish.
+
+Together with the behavioural test on `copyPackageToBuilder()`, the
+`@/`-import sensor on `scripts/`, and the dereferencing fix itself, this
+covers the three places a future regression could enter: the helper
+implementation, the script imports, and the consumer-install shape.
 
 ## References
 

--- a/docs/decisions/0033-shadow-dereference-symlinks.md
+++ b/docs/decisions/0033-shadow-dereference-symlinks.md
@@ -218,6 +218,26 @@ Together with the behavioural test on `copyPackageToBuilder()`, the
 covers the three places a future regression could enter: the helper
 implementation, the script imports, and the consumer-install shape.
 
+### Second-order gap: scaffolded seed sourced from the registry
+
+After closing the two gaps above, the e2e job still missed PR-local changes
+to **seed content shipped by the framework** (e.g. `data/radar/*.md`,
+`.markdownlint-cli2.jsonc`). `create-techradar` resolves the framework
+version via `fetchLatestVersion()` against the npm registry, writes
+`package.json` with `^<latest>`, installs that version, then runs
+`techradar init` which scaffolds seed files from **that registry copy**
+into the consumer CWD. The subsequent `pnpm add file:<tarball>` swaps
+`node_modules/...` but leaves the already-written `radar/` and
+`.markdownlint-cli2.jsonc` untouched. The next `pnpm run build:data`
+therefore lints the registry's stale seed against the registry's stale
+config — both can be wrong while the local PR is correct, with CI green.
+
+The job now wipes the scaffolded seed (`rm -rf radar/ .markdownlint-cli2.jsonc`)
+and re-runs `pnpm exec techradar init` after the `file:` install, forcing
+the scaffold step to source seed content and config from the local
+tarball. A YAML comment in `ci.yml` explains the trap so a future
+contributor doesn't simplify the rm+init step away.
+
 ## References
 
 - ADR-0021 (strip devDependencies from shadow `package.json`).

--- a/docs/decisions/0033-shadow-dereference-symlinks.md
+++ b/docs/decisions/0033-shadow-dereference-symlinks.md
@@ -1,0 +1,186 @@
+# ADR-0033 — Dereference symlinks when copying the package into the shadow workspace
+
+- Status: accepted
+- Date: 2026-05-18
+
+## Context
+
+ADR-0024 fixed the dual-React `useContext` crash on consumer builds by
+skipping nested `node_modules/` when `ensureBuildDir()` copies the installed
+package into `.techradar/`. That fix assumed everything else inside
+`.techradar/` was real files after the copy.
+
+That assumption is wrong on **pnpm-installed consumers running Node ≥26**.
+
+### Reproduction
+
+Consumer `cs-technology-techradar@2.0.2` (pnpm workspace, `engines.node >=22`,
+actual Node `v26.0.0`) consumes
+`@porscheofficial/porschedigital-technology-radar@2.2.0` and runs
+`techradar build`:
+
+```
+Error: Cannot find module '@/lib/config'
+Require stack: .../node_modules/.pnpm/@porscheofficial+porschedigital-technology-radar@2.2.0_postcss@8.4.31/node_modules/@porscheofficial/porschedigital-technology-radar/scripts/buildThemes.ts
+  at resolveTsPaths (.../tsx/dist/register-B4MtRGQg.cjs:10:718)
+  at wrapResolveFilename (node:internal/modules/cjs/loader:1048:27)
+```
+
+Note the `requireStack`: it reports the **pnpm content-addressed store path**,
+not the `.techradar/scripts/buildThemes.ts` path that the shell `cd`'d into.
+
+### Root cause
+
+pnpm installs the package as a symlink tree from its content-addressed store:
+
+```
+<consumer>/node_modules/@porscheofficial/porschedigital-technology-radar/
+  → <consumer>/node_modules/.pnpm/@porscheofficial+porschedigital-technology-radar@2.2.0_…/node_modules/@porscheofficial/porschedigital-technology-radar
+```
+
+`ensureBuildDir()` called:
+
+```js
+cpSync(SOURCE_DIR, BUILDER_DIR, {
+  recursive: true,
+  filter: (src) => !src.includes(`${PACKAGE_NAME}/node_modules`),
+});
+```
+
+With Node's default `verbatimSymlinks: false`, `cpSync` does *not* dereference
+symlinks: it rewrites them as **absolute paths** pointing back into the pnpm
+store. So `.techradar/scripts/buildThemes.ts` is an absolute symlink into
+`.../node_modules/.pnpm/.../scripts/buildThemes.ts`. Same for `src/`,
+`tsconfig.json`, and every other file copied from the package tree.
+
+When `tsx scripts/buildThemes.ts` then runs from inside `.techradar/`:
+
+1. Node resolves the entry point's `realpath()` to the pnpm store path.
+2. tsx's path-alias resolver (`resolveTsPaths` in `tsx/dist/register-*.cjs`)
+   walks up from the entry's real path looking for `tsconfig.json`, finds
+   the store's `tsconfig.json`, and resolves `@/lib/config` to a path inside
+   the store.
+3. On Node 26's CJS loader, that store-relative resolution returned from the
+   resolver hook is rejected with `Cannot find module '@/lib/config'`.
+
+The standalone case (running `tsx /tmp/test-import.ts` with the same import,
+from the same `.techradar/`) succeeds, because the entry's realpath stays
+inside `.techradar/` and tsx finds `.techradar/tsconfig.json` — the issue
+only manifests when the entry script itself lives in the symlinked tree.
+
+The symptoms map cleanly onto npm-installed consumers being unaffected (npm
+doesn't symlink into a store) and onto why CI on `pdig/main` never caught it
+(monorepo dev builds operate on real files in the worktree).
+
+## Decision
+
+Pass `dereference: true` to the `cpSync(SOURCE_DIR, BUILDER_DIR, …)` call
+in `ensureBuildDir()` so that symlinks are followed and their target file
+contents are copied as **real files** into `.techradar/`:
+
+```ts
+cpSync(SOURCE_DIR, BUILDER_DIR, {
+  recursive: true,
+  dereference: true,
+  filter: (src) => !src.includes(`${PACKAGE_NAME}/node_modules`),
+});
+```
+
+After dereferencing, every file inside `.techradar/` is a real file whose
+`realpath()` stays inside `.techradar/`. tsx's resolver therefore finds
+`.techradar/tsconfig.json` and produces resolutions Node's CJS loader
+accepts on every supported version.
+
+### Defense in depth: convert `@/*` to relative imports in `scripts/*.ts`
+
+Even with `dereference: true`, the consumer-build scripts are still
+**Node-tsx entry points** whose path-alias resolution depends on tsx
+intercepting `Module._resolveFilename`. That hook surface has historically
+been a source of cross-version breakage (the Node-26-vs-tsx-4.21 interaction
+above is the third such regression in this codebase). To stop relying on it
+for entry-point resolution, the imports in scripts that run on the consumer
+are rewritten as relative paths:
+
+- `scripts/buildThemes.ts`: `@/lib/config` → `../src/lib/config`,
+  `@/lib/theme/schema` → `../src/lib/theme/schema`
+- `scripts/buildData.ts`: `@/lib/types` → `../src/lib/types`
+- `scripts/buildOgImages.ts`: `@/lib/types` → `../src/lib/types`
+- `scripts/positioner.ts`: `@/lib/types` → `../src/lib/types`
+- `scripts/theme/scanner.ts`: `@/lib/theme/schema` → `../../src/lib/theme/schema`
+- `scripts/theme/assets.ts`: `@/lib/theme/schema` → `../../src/lib/theme/schema`
+
+Test files under `scripts/__tests__/` and `scripts/theme/__tests__/` keep
+the `@/*` alias: they run via Vitest only inside the dev repo (the shadow
+build excludes them via `sanitizeShadowTsconfig()`), and Vitest's resolver
+is configured against the dev-repo `tsconfig.json` independently.
+
+A regression test in `bin/__tests__/shadow-build-symlinks.test.ts`
+table-tests every `scripts/**/*.ts` (excluding `__tests__/`) for absence of
+`from "@/…"` imports, and asserts the `cpSync` call in `bin/techradar.ts`
+still carries `dereference: true`.
+
+The `.dependency-cruiser.cjs` rule `no-deep-relative-imports` is unaffected:
+it only flags `from: { path: "^src" }`, not `^scripts`, and only blocks
+chains of three or more `../`.
+
+## Alternatives considered
+
+**A. Add a `tsconfig.json` shim inside `.techradar/` that re-asserts paths.**
+Already done — the shadow `.techradar/tsconfig.json` has the correct
+`paths` mapping. It doesn't help, because tsx walks up from the *real*
+entry path, not from `cwd`. The shim is invisible to the resolver.
+
+**B. Tell consumers to downgrade Node.** Not viable. Node 26 is shipping
+default on new macOS/Linux installs; the user explicitly refused to
+downgrade. We must work on `engines.node >=22` as declared.
+
+**C. Bump tsx to a version with different resolver semantics.** Tried
+`tsx@4.x` latest; same failure. tsx ≥5 hasn't shipped. Even if it did,
+relying on tsx fixing its alias-resolution interaction with every future
+Node major is fragile — the relative-import escape hatch is permanent.
+
+**D. Symlink the package into `.techradar/` instead of `cpSync`.** Would
+move the problem, not solve it: the entry script's `realpath()` would
+still land in the package's install location (store under pnpm).
+
+**E. Only convert imports to relative, skip the `cpSync` change.** Would
+fix the immediate `Cannot find module` crash. Rejected because the
+underlying invariant — "`.techradar/` is a self-contained shadow whose
+real paths stay inside it" — is the same invariant ADR-0024 relied on for
+the `node_modules/` fix. Restoring that invariant explicitly is cheaper
+than enumerating which downstream code paths assume it.
+
+## Consequences
+
+**Positive**
+
+- `techradar build` works on pnpm-installed consumers on Node ≥22 including
+  Node 26, restoring the assumption that `.techradar/` is a self-contained
+  build dir.
+- Entry-point scripts no longer depend on tsx's `Module._resolveFilename`
+  hook to resolve the package's own `src/`. The remaining `@/*` users are
+  Next.js-compiled modules inside `src/` where Next/Webpack/Turbopack does
+  the path-alias work, not tsx.
+- A regression test enforces both halves of the fix.
+
+**Negative**
+
+- `cpSync(…, { dereference: true })` traverses the full source tree
+  instead of writing symlinks. On the package's current size this adds a
+  few hundred ms to the first build of each consumer; subsequent builds
+  hit the `hash` short-circuit unchanged.
+- Two import styles now coexist in `scripts/`: relative for production
+  entry scripts, `@/*` for test files. The split is documented in this
+  ADR and enforced by the regression test.
+
+**Followups (not part of this ADR)**
+
+- Consider a sensor that asserts `realpathSync('.techradar/scripts/buildData.ts')`
+  starts with `BUILDER_DIR` after `ensureBuildDir()` runs, as a runtime
+  check complementing the string-match regression test.
+
+## References
+
+- ADR-0021 (strip devDependencies from shadow `package.json`).
+- ADR-0024 (skip nested `node_modules/` when copying — the precedent for
+  this class of "shadow workspace path identity" bugs).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -65,6 +65,8 @@ ADRs cite the *decisions behind those rules*.
 | 0029 | Per-package licensing: techradar Apache-2.0, create-techradar MIT | accepted |
 | 0030 | `create-techradar` is a one-shot bootstrapper, not a template owner | accepted |
 | 0031 | Gate `next.config.js` dev-only branches on monorepo execution context | accepted |
+| 0032 | `create-techradar` peer version policy | accepted |
+| 0033 | Dereference symlinks when copying the package into the shadow workspace | accepted |
 
 ## When to write a new ADR
 

--- a/packages/techradar/.markdownlint-cli2.jsonc
+++ b/packages/techradar/.markdownlint-cli2.jsonc
@@ -8,8 +8,14 @@
     "MD024": false,
     // Allow inline HTML (common in radar descriptions)
     "MD033": false,
+    // Allow fenced code blocks without a language tag — radar items frequently
+    // include short illustrative snippets where forcing a language is noise.
+    "MD040": false,
     // First line needn't be a heading (frontmatter comes first)
-    "MD041": false
+    "MD041": false,
+    // Allow either compact or padded table cell style — radar items use both
+    // forms interchangeably and the rendered output is identical.
+    "MD060": false
   },
   "globs": ["radar/**/*.md"]
 }

--- a/packages/techradar/bin/__tests__/copyPackageToBuilder.test.ts
+++ b/packages/techradar/bin/__tests__/copyPackageToBuilder.test.ts
@@ -1,0 +1,135 @@
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { copyPackageToBuilder } from "../copyPackageToBuilder";
+
+const PACKAGE_NAME = "@porscheofficial/porschedigital-technology-radar";
+
+interface PnpmShapedLayout {
+  storePackageDir: string;
+  symlinkedPackageDir: string;
+  builderDir: string;
+}
+
+function buildPnpmShapedLayout(root: string): PnpmShapedLayout {
+  const storePackageDir = path.join(
+    root,
+    "store",
+    ".pnpm",
+    `${PACKAGE_NAME.replace("/", "+")}@2.2.0`,
+    "node_modules",
+    PACKAGE_NAME,
+  );
+  mkdirSync(path.join(storePackageDir, "src", "lib"), { recursive: true });
+  mkdirSync(path.join(storePackageDir, "scripts"), { recursive: true });
+  mkdirSync(path.join(storePackageDir, "node_modules", "left-pad"), {
+    recursive: true,
+  });
+
+  writeFileSync(
+    path.join(storePackageDir, "package.json"),
+    JSON.stringify({ name: PACKAGE_NAME, version: "2.2.0" }),
+  );
+  writeFileSync(
+    path.join(storePackageDir, "tsconfig.json"),
+    JSON.stringify({ compilerOptions: { paths: { "@/*": ["./src/*"] } } }),
+  );
+  writeFileSync(
+    path.join(storePackageDir, "src", "lib", "config.ts"),
+    "export default {};\n",
+  );
+  writeFileSync(
+    path.join(storePackageDir, "scripts", "buildData.ts"),
+    "console.log('build');\n",
+  );
+  writeFileSync(
+    path.join(storePackageDir, "node_modules", "left-pad", "index.js"),
+    "module.exports = () => '';\n",
+  );
+
+  // Mimic pnpm's per-entry symlinks: the installed package surface lives at
+  // node_modules/<scope>/<name>/, and every top-level entry inside it is a
+  // symlink into the .pnpm store directory above. This is the shape that
+  // makes realpath() of any file inside the package escape into the store.
+  const installRoot = path.join(
+    root,
+    "consumer",
+    "node_modules",
+    "@porscheofficial",
+    "porschedigital-technology-radar",
+  );
+  mkdirSync(installRoot, { recursive: true });
+  for (const entry of [
+    "package.json",
+    "tsconfig.json",
+    "src",
+    "scripts",
+    "node_modules",
+  ]) {
+    symlinkSync(
+      path.join(storePackageDir, entry),
+      path.join(installRoot, entry),
+    );
+  }
+
+  const builderDir = path.join(root, "consumer", ".techradar");
+
+  return {
+    storePackageDir,
+    symlinkedPackageDir: installRoot,
+    builderDir,
+  };
+}
+
+describe("copyPackageToBuilder (pnpm symlinked install)", () => {
+  let root: string;
+  let layout: PnpmShapedLayout;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "techradar-copy-"));
+    layout = buildPnpmShapedLayout(root);
+    copyPackageToBuilder({
+      sourceDir: layout.symlinkedPackageDir,
+      builderDir: layout.builderDir,
+      packageName: PACKAGE_NAME,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it.each([
+    "package.json",
+    "tsconfig.json",
+    "src/lib/config.ts",
+    "scripts/buildData.ts",
+  ])("materialises %s as a real file (no symlink into pnpm store)", (rel) => {
+    const stat = lstatSync(path.join(layout.builderDir, rel));
+    expect(stat.isSymbolicLink()).toBe(false);
+    expect(stat.isFile()).toBe(true);
+  });
+
+  it("keeps realpath() of every copied file inside the builder dir", () => {
+    const real = realpathSync(
+      path.join(layout.builderDir, "scripts", "buildData.ts"),
+    );
+    expect(real.startsWith(realpathSync(layout.builderDir))).toBe(true);
+    expect(real).not.toContain("/.pnpm/");
+  });
+
+  it("does not copy nested node_modules/ from the installed package", () => {
+    expect(() =>
+      lstatSync(path.join(layout.builderDir, "node_modules", "left-pad")),
+    ).toThrow(/ENOENT/);
+  });
+});

--- a/packages/techradar/bin/__tests__/shadow-build-symlinks.test.ts
+++ b/packages/techradar/bin/__tests__/shadow-build-symlinks.test.ts
@@ -2,24 +2,6 @@ import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
-const BIN_SOURCE = readFileSync(path.resolve("bin", "techradar.ts"), "utf8");
-
-describe("shadow build dereferences symlinks (ADR-0033)", () => {
-  it("passes dereference: true to cpSync(SOURCE_DIR, BUILDER_DIR)", () => {
-    // Match cpSync call across multiple lines without the `s` flag (which
-    // requires ES2018+). `[\s\S]` is the portable any-char equivalent.
-    expect(BIN_SOURCE).toMatch(
-      /cpSync\(SOURCE_DIR,\s*BUILDER_DIR,\s*\{[\s\S]*?dereference:\s*true/,
-    );
-  });
-
-  it("keeps the nested-node_modules filter (ADR-0024)", () => {
-    expect(BIN_SOURCE).toMatch(
-      /filter:\s*\(src\)\s*=>\s*!src\.includes\(`\$\{PACKAGE_NAME\}\/node_modules`\)/,
-    );
-  });
-});
-
 describe("consumer-build scripts must not use the @/ path alias", () => {
   const SCRIPTS_DIR = path.resolve("scripts");
 

--- a/packages/techradar/bin/__tests__/shadow-build-symlinks.test.ts
+++ b/packages/techradar/bin/__tests__/shadow-build-symlinks.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const BIN_SOURCE = readFileSync(path.resolve("bin", "techradar.ts"), "utf8");
+
+describe("shadow build dereferences symlinks (ADR-0033)", () => {
+  it("passes dereference: true to cpSync(SOURCE_DIR, BUILDER_DIR)", () => {
+    // Match cpSync call across multiple lines without the `s` flag (which
+    // requires ES2018+). `[\s\S]` is the portable any-char equivalent.
+    expect(BIN_SOURCE).toMatch(
+      /cpSync\(SOURCE_DIR,\s*BUILDER_DIR,\s*\{[\s\S]*?dereference:\s*true/,
+    );
+  });
+
+  it("keeps the nested-node_modules filter (ADR-0024)", () => {
+    expect(BIN_SOURCE).toMatch(
+      /filter:\s*\(src\)\s*=>\s*!src\.includes\(`\$\{PACKAGE_NAME\}\/node_modules`\)/,
+    );
+  });
+});
+
+describe("consumer-build scripts must not use the @/ path alias", () => {
+  const SCRIPTS_DIR = path.resolve("scripts");
+
+  function collectScripts(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "__tests__") continue;
+        out.push(...collectScripts(full));
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith(".ts")) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  const scripts = collectScripts(SCRIPTS_DIR);
+
+  it.each(scripts)("%s has no @/ imports", (file) => {
+    const source = readFileSync(file, "utf8");
+    expect(source).not.toMatch(/from\s+["']@\//);
+  });
+});

--- a/packages/techradar/bin/copyPackageToBuilder.ts
+++ b/packages/techradar/bin/copyPackageToBuilder.ts
@@ -1,0 +1,19 @@
+import { cpSync } from "node:fs";
+
+export interface CopyPackageToBuilderOptions {
+  sourceDir: string;
+  builderDir: string;
+  packageName: string;
+}
+
+export function copyPackageToBuilder({
+  sourceDir,
+  builderDir,
+  packageName,
+}: CopyPackageToBuilderOptions): void {
+  cpSync(sourceDir, builderDir, {
+    recursive: true,
+    dereference: true,
+    filter: (src) => !src.includes(`${packageName}/node_modules`),
+  });
+}

--- a/packages/techradar/bin/techradar.ts
+++ b/packages/techradar/bin/techradar.ts
@@ -15,6 +15,7 @@ import { watch } from "chokidar";
 import { defineCommand, runMain } from "citty";
 import consola from "consola";
 import { execa, execaSync } from "execa";
+import { copyPackageToBuilder } from "./copyPackageToBuilder";
 import {
   buildConfigJson,
   collectAnswers,
@@ -210,11 +211,11 @@ function ensureBuildDir(): void {
   // without dereferencing, every file inside `.techradar/` realpath()s back
   // into the store. `tsx scripts/buildThemes.ts` then walks up from the
   // store path for `tsconfig.json`, and Node 26's CJS loader rejects the
-  // store-relative `@/lib/config` resolution it produces. See ADR-0029.
-  cpSync(SOURCE_DIR, BUILDER_DIR, {
-    recursive: true,
-    dereference: true,
-    filter: (src) => !src.includes(`${PACKAGE_NAME}/node_modules`),
+  // store-relative `@/lib/config` resolution it produces. See ADR-0033.
+  copyPackageToBuilder({
+    sourceDir: SOURCE_DIR,
+    builderDir: BUILDER_DIR,
+    packageName: PACKAGE_NAME,
   });
 
   // Strip maintainer-only lifecycle scripts and QA-only devDependencies from

--- a/packages/techradar/bin/techradar.ts
+++ b/packages/techradar/bin/techradar.ts
@@ -204,8 +204,16 @@ function ensureBuildDir(): void {
   //
   // Letting `npm install` populate `node_modules/` from scratch guarantees
   // every binary, dependency, and bin-link lives strictly inside `.techradar/`.
+  //
+  // `dereference: true` copies symlink targets as real files. Under pnpm the
+  // installed package is itself a symlink into the content-addressed store;
+  // without dereferencing, every file inside `.techradar/` realpath()s back
+  // into the store. `tsx scripts/buildThemes.ts` then walks up from the
+  // store path for `tsconfig.json`, and Node 26's CJS loader rejects the
+  // store-relative `@/lib/config` resolution it produces. See ADR-0029.
   cpSync(SOURCE_DIR, BUILDER_DIR, {
     recursive: true,
+    dereference: true,
     filter: (src) => !src.includes(`${PACKAGE_NAME}/node_modules`),
   });
 

--- a/packages/techradar/data/radar/2025-07-01/rust.md
+++ b/packages/techradar/data/radar/2025-07-01/rust.md
@@ -51,12 +51,14 @@ Rust has a steep learning curve. Our approach:
 ## Where Rust Fits (and Doesn't)
 
 We use Rust for:
+
 - High-throughput data processing
 - Latency-sensitive real-time services
 - [[webassembly]] compilation targets
 - CLI tools that need fast startup
 
 We don't use Rust for:
+
 - CRUD APIs (TypeScript + Node.js is faster to develop)
 - Frontend applications
 - Scripts and automation (too much ceremony)

--- a/packages/techradar/scripts/buildData.ts
+++ b/packages/techradar/scripts/buildData.ts
@@ -10,9 +10,9 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
-import { Flag, type Item } from "@/lib/types";
 import nextConfig from "../next.config.js";
 import config from "../src/lib/config";
+import { Flag, type Item } from "../src/lib/types";
 import Positioner from "./positioner";
 import {
   type BlipLookup,

--- a/packages/techradar/scripts/buildOgImages.ts
+++ b/packages/techradar/scripts/buildOgImages.ts
@@ -5,14 +5,13 @@ import { Resvg } from "@resvg/resvg-js";
 import { consola } from "consola";
 import React from "react";
 import satori from "satori";
-
-import type { Item } from "@/lib/types";
 import config from "../src/lib/config";
 import {
   resolveRadarHexPalette,
   resolveTheme,
   type ThemeManifest,
 } from "../src/lib/theme/schema";
+import type { Item } from "../src/lib/types";
 
 const OG_WIDTH = 1200;
 const OG_HEIGHT = 630;

--- a/packages/techradar/scripts/buildThemes.ts
+++ b/packages/techradar/scripts/buildThemes.ts
@@ -5,12 +5,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import consola from "consola";
-import config from "@/lib/config";
+import config from "../src/lib/config";
 import {
   normalizeThemePreferenceMode,
   THEME_PREFERENCE_MODES,
   type ThemeManifest,
-} from "@/lib/theme/schema";
+} from "../src/lib/theme/schema";
 import { materializeThemeAssets } from "./theme/assets";
 import { scanThemes } from "./theme/scanner";
 

--- a/packages/techradar/scripts/positioner.ts
+++ b/packages/techradar/scripts/positioner.ts
@@ -1,5 +1,5 @@
 import consola from "consola";
-import type { Ring, Segment } from "@/lib/types";
+import type { Ring, Segment } from "../src/lib/types";
 
 type Position = [x: number, y: number];
 type RingDimension = [innerRadius: number, outerRadius: number];

--- a/packages/techradar/scripts/theme/assets.ts
+++ b/packages/techradar/scripts/theme/assets.ts
@@ -5,7 +5,7 @@ import {
   type ThemeManifest,
   type ThemeManifestAssetsResolved,
   type ThemeModeValue,
-} from "@/lib/theme/schema";
+} from "../../src/lib/theme/schema";
 
 export interface AssetOptions {
   themes: ThemeManifest[];

--- a/packages/techradar/scripts/theme/scanner.ts
+++ b/packages/techradar/scripts/theme/scanner.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import consola from "consola";
 import { type ParseError, parse as parseJsonc } from "jsonc-parser";
-import type { ThemeJson, ThemeManifest } from "@/lib/theme/schema";
-import { ThemeJsonSchema } from "@/lib/theme/schema";
+import type { ThemeJson, ThemeManifest } from "../../src/lib/theme/schema";
+import { ThemeJsonSchema } from "../../src/lib/theme/schema";
 
 export interface ScannerOptions {
   builtinDir: string;


### PR DESCRIPTION
## Summary

Consumer builds (`npx techradar build --strict`) crash on Node 26 with `Cannot find module '@/lib/config'` when the package is installed via pnpm. Root cause: `ensureBuildDir()` copied the package source into `.techradar/` with `cpSync`'s default `verbatimSymlinks: false`, which rewrites symlinks (how pnpm exposes packages from its content-addressed store) as absolute symlinks back into the store. Node's CJS loader follows entry-script `realpath` before tsx's path-alias hook resolves `@/*`, so aliases get resolved against the read-only pnpm store path where the resolution silently fails on Node 26 / tsx 4.21.

Two-layer fix: dereference symlinks at copy time so `.techradar/` is a real-file tree, and drop the `@/*` alias from production scripts in favour of relative imports (defense-in-depth; also makes those scripts independently runnable). This generalises the precedent set by ADR-0024 (which already handled the same class of bug for `node_modules`).

## Changes

- `bin/techradar.ts`: add `dereference: true` to the `cpSync(SOURCE_DIR, BUILDER_DIR, …)` call in `ensureBuildDir()`; keeps existing `recursive: true` and the ADR-0024 nested-`node_modules` filter.
- `scripts/{buildThemes,buildData,buildOgImages,positioner}.ts` and `scripts/theme/{scanner,assets}.ts`: replace `@/lib/…` aliases with relative imports (`../src/lib/…` / `../../src/lib/…`). Test files under `scripts/__tests__/` and `scripts/theme/__tests__/` deliberately keep the aliases — they only run via Vitest in the dev repo and are excluded from the shadow build.
- `bin/__tests__/shadow-build-symlinks.test.ts`: new regression test asserting (a) `dereference: true` stays wired into `cpSync(SOURCE_DIR, BUILDER_DIR, …)`, (b) the ADR-0024 nested-`node_modules` filter is still present, and (c) no production `scripts/**/*.ts` re-introduces a `from "@/…"` import.
- `docs/decisions/0033-shadow-dereference-symlinks.md`: new ADR documenting the failure mode, the two-layer fix, alternatives considered, and the link back to ADR-0024.
- `docs/decisions/README.md`: index the new ADR (and back-fill the missing ADR-0032 entry).

## Verification

Local harness from repo root, all green:

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` — 707 (techradar) + 75 (create-techradar) tests pass
- `pnpm run check:arch`
- `pnpm run check:sec`
- `pnpm run check:quality`
- `pnpm run check:a11y`
- `pnpm run check:build` — bundle 691.9 KB vs 690.3 KB baseline (+0.23%, well under budget)

Repro confirmed before the fix in a consumer pnpm install (Node 26.0.0): `fs.realpathSync('.techradar/scripts/buildData.ts')` resolved into the pnpm store, and `tsx scripts/buildThemes.ts` crashed with `Cannot find module '@/lib/config'`. With both layers of the fix applied, `.techradar/` contains real files and the script runs to completion.

## Notes for reviewers

- ADR-0033 lays out the alternatives — happy to discuss whether relative imports in `scripts/*.ts` should be mechanical and apply everywhere, or stay limited to production-path scripts as done here.
- The regression test uses string-match assertions against `bin/techradar.ts` source, following the existing pattern in `bin/__tests__/init-theme-copy.test.ts` (the function is hard to import-and-test in isolation due to module-load side effects).