### PR TITLE
fix(techradar): align theme palette with user-chosen segments and rings count

### DIFF
--- a/packages/techradar/bin/__tests__/resizeThemePalette.test.ts
+++ b/packages/techradar/bin/__tests__/resizeThemePalette.test.ts
@@ -1,0 +1,204 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parse as parseJsonc } from "jsonc-parser";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  resizeThemeManifestFile,
+  resizeThemeManifestPalettes,
+} from "../resizeThemePalette";
+
+const BASE_MANIFEST = `{
+  // Annotated manifest — comments must survive surgical resize.
+  "label": "Test",
+  "supports": ["light", "dark"],
+  "default": "dark",
+  "cssVariables": {
+    "foreground": { "light": "#111", "dark": "#FFF" }
+  },
+  "radar": {
+    "segments": [
+      { "light": "#A", "dark": "#a" },
+      { "light": "#B", "dark": "#b" },
+      { "light": "#C", "dark": "#c" },
+      { "light": "#D", "dark": "#d" }
+    ],
+    "rings": [
+      { "light": "#R1", "dark": "#r1" },
+      { "light": "#R2", "dark": "#r2" }
+    ]
+  }
+}
+`;
+
+describe("resizeThemeManifestPalettes", () => {
+  it("is a no-op when both palettes already match", () => {
+    const { source, outcome } = resizeThemeManifestPalettes(
+      BASE_MANIFEST,
+      4,
+      2,
+    );
+    expect(source).toBe(BASE_MANIFEST);
+    expect(outcome.changed).toBe(false);
+    expect(outcome.segments).toEqual({ before: 4, after: 4 });
+    expect(outcome.rings).toEqual({ before: 2, after: 2 });
+  });
+
+  it("grows the segments palette by cycling existing colours", () => {
+    const { source, outcome } = resizeThemeManifestPalettes(
+      BASE_MANIFEST,
+      7,
+      2,
+    );
+    expect(outcome.changed).toBe(true);
+    expect(outcome.segments).toEqual({ before: 4, after: 7 });
+
+    const parsed = parseJsonc(source) as {
+      radar: { segments: Array<{ light: string }>; rings: unknown[] };
+    };
+    expect(parsed.radar.segments).toHaveLength(7);
+    expect(parsed.radar.segments.map((c) => c.light)).toEqual([
+      "#A",
+      "#B",
+      "#C",
+      "#D",
+      "#A",
+      "#B",
+      "#C",
+    ]);
+    expect(parsed.radar.rings).toHaveLength(2);
+  });
+
+  it("shrinks the segments palette by truncation", () => {
+    const { source, outcome } = resizeThemeManifestPalettes(
+      BASE_MANIFEST,
+      2,
+      2,
+    );
+    expect(outcome.changed).toBe(true);
+    expect(outcome.segments).toEqual({ before: 4, after: 2 });
+
+    const parsed = parseJsonc(source) as {
+      radar: { segments: Array<{ light: string }> };
+    };
+    expect(parsed.radar.segments.map((c) => c.light)).toEqual(["#A", "#B"]);
+  });
+
+  it("grows both palettes independently in one pass", () => {
+    const { source, outcome } = resizeThemeManifestPalettes(
+      BASE_MANIFEST,
+      5,
+      6,
+    );
+    expect(outcome.changed).toBe(true);
+
+    const parsed = parseJsonc(source) as {
+      radar: {
+        segments: Array<{ light: string }>;
+        rings: Array<{ light: string }>;
+      };
+    };
+    expect(parsed.radar.segments.map((c) => c.light)).toEqual([
+      "#A",
+      "#B",
+      "#C",
+      "#D",
+      "#A",
+    ]);
+    expect(parsed.radar.rings.map((c) => c.light)).toEqual([
+      "#R1",
+      "#R2",
+      "#R1",
+      "#R2",
+      "#R1",
+      "#R2",
+    ]);
+  });
+
+  it("preserves leading comments", () => {
+    const { source } = resizeThemeManifestPalettes(BASE_MANIFEST, 5, 5);
+    expect(source).toContain("// Annotated manifest");
+  });
+
+  it("preserves unrelated fields untouched", () => {
+    const { source } = resizeThemeManifestPalettes(BASE_MANIFEST, 5, 5);
+    const parsed = parseJsonc(source) as {
+      label: string;
+      supports: string[];
+      cssVariables: { foreground: { light: string } };
+    };
+    expect(parsed.label).toBe("Test");
+    expect(parsed.supports).toEqual(["light", "dark"]);
+    expect(parsed.cssVariables.foreground.light).toBe("#111");
+  });
+
+  it("rejects counts below 1", () => {
+    expect(() => resizeThemeManifestPalettes(BASE_MANIFEST, 0, 1)).toThrow(
+      /counts must be >= 1/,
+    );
+    expect(() => resizeThemeManifestPalettes(BASE_MANIFEST, 1, 0)).toThrow(
+      /counts must be >= 1/,
+    );
+  });
+
+  it("rejects manifests with no radar object", () => {
+    expect(() => resizeThemeManifestPalettes(`{ "label": "x" }`, 4, 4)).toThrow(
+      /no `radar` object/,
+    );
+  });
+
+  it("rejects manifests where segments/rings are not arrays", () => {
+    const bad = `{ "radar": { "segments": "nope", "rings": [{"light":"#1","dark":"#1"}] } }`;
+    expect(() => resizeThemeManifestPalettes(bad, 4, 4)).toThrow(
+      /must be arrays/,
+    );
+  });
+
+  it("rejects manifests with an empty source palette", () => {
+    const bad = `{ "radar": { "segments": [], "rings": [{"light":"#1","dark":"#1"}] } }`;
+    expect(() => resizeThemeManifestPalettes(bad, 4, 4)).toThrow(
+      /source palette is empty/,
+    );
+  });
+
+  it("propagates JSONC parse errors", () => {
+    expect(() => resizeThemeManifestPalettes("{ not json", 4, 4)).toThrow(
+      /JSONC parse error/,
+    );
+  });
+});
+
+describe("resizeThemeManifestFile", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "resize-theme-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes the file when changed and reports the outcome", () => {
+    const file = path.join(dir, "manifest.jsonc");
+    writeFileSync(file, BASE_MANIFEST);
+    const outcome = resizeThemeManifestFile(file, 5, 3);
+    expect(outcome.changed).toBe(true);
+    const written = readFileSync(file, "utf8");
+    expect(written).not.toBe(BASE_MANIFEST);
+    const parsed = parseJsonc(written) as {
+      radar: { segments: unknown[]; rings: unknown[] };
+    };
+    expect(parsed.radar.segments).toHaveLength(5);
+    expect(parsed.radar.rings).toHaveLength(3);
+  });
+
+  it("does not touch the file when no resize is needed", () => {
+    const file = path.join(dir, "manifest.jsonc");
+    writeFileSync(file, BASE_MANIFEST);
+    const before = readFileSync(file, "utf8");
+    const outcome = resizeThemeManifestFile(file, 4, 2);
+    expect(outcome.changed).toBe(false);
+    expect(readFileSync(file, "utf8")).toBe(before);
+  });
+});

--- a/packages/techradar/bin/resizeThemePalette.ts
+++ b/packages/techradar/bin/resizeThemePalette.ts
@@ -1,0 +1,152 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import {
+  applyEdits,
+  type FormattingOptions,
+  modify,
+  type ParseError,
+  parse as parseJsonc,
+} from "jsonc-parser";
+
+const FORMATTING: FormattingOptions = {
+  insertSpaces: true,
+  tabSize: 2,
+  eol: "\n",
+};
+
+type PaletteEntry = unknown;
+
+interface ResizeOutcome {
+  changed: boolean;
+  segments: { before: number; after: number };
+  rings: { before: number; after: number };
+}
+
+function cyclePalette(
+  source: PaletteEntry[],
+  targetLength: number,
+): PaletteEntry[] {
+  if (source.length === 0) {
+    throw new Error(
+      "cyclePalette: source palette is empty — Zod schema requires .min(1); refusing to resize from zero",
+    );
+  }
+  const out: PaletteEntry[] = new Array(targetLength);
+  for (let i = 0; i < targetLength; i += 1) {
+    out[i] = source[i % source.length];
+  }
+  return out;
+}
+
+/**
+ * Resize the `radar.segments` and `radar.rings` palette arrays inside a
+ * theme `manifest.jsonc` to match the consumer's chosen taxonomy size.
+ *
+ * Uses `jsonc-parser`'s surgical `modify`/`applyEdits` so comments and the
+ * surrounding formatting are preserved — annotated themes like
+ * `data/themes/.example/manifest.jsonc` keep their documentation intact.
+ *
+ * Returns metadata describing what changed. Throws only on JSONC parse
+ * errors or structurally invalid manifests (missing `radar.segments` /
+ * `radar.rings` arrays). Length mismatches alone are NOT errors; this
+ * function is the fix for them.
+ */
+export function resizeThemeManifestPalettes(
+  manifestSource: string,
+  segmentsCount: number,
+  ringsCount: number,
+): { source: string; outcome: ResizeOutcome } {
+  if (segmentsCount < 1 || ringsCount < 1) {
+    throw new Error(
+      `resizeThemeManifestPalettes: counts must be >= 1 (got segments=${segmentsCount}, rings=${ringsCount})`,
+    );
+  }
+
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(manifestSource, errors, {
+    allowTrailingComma: true,
+  }) as unknown;
+
+  if (errors.length > 0) {
+    const detail = errors
+      .map((e) => `offset ${e.offset}: error code ${e.error}`)
+      .join("; ");
+    throw new Error(
+      `resizeThemeManifestPalettes: JSONC parse error — ${detail}`,
+    );
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("radar" in parsed) ||
+    typeof (parsed as { radar: unknown }).radar !== "object" ||
+    (parsed as { radar: unknown }).radar === null
+  ) {
+    throw new Error(
+      "resizeThemeManifestPalettes: manifest has no `radar` object",
+    );
+  }
+
+  const radar = (parsed as { radar: { segments?: unknown; rings?: unknown } })
+    .radar;
+
+  if (!Array.isArray(radar.segments) || !Array.isArray(radar.rings)) {
+    throw new Error(
+      "resizeThemeManifestPalettes: `radar.segments` and `radar.rings` must be arrays",
+    );
+  }
+
+  const currentSegments = radar.segments as PaletteEntry[];
+  const currentRings = radar.rings as PaletteEntry[];
+
+  let working = manifestSource;
+  let changed = false;
+
+  if (currentSegments.length !== segmentsCount) {
+    const next = cyclePalette(currentSegments, segmentsCount);
+    const edits = modify(working, ["radar", "segments"], next, {
+      formattingOptions: FORMATTING,
+    });
+    working = applyEdits(working, edits);
+    changed = true;
+  }
+
+  if (currentRings.length !== ringsCount) {
+    const next = cyclePalette(currentRings, ringsCount);
+    const edits = modify(working, ["radar", "rings"], next, {
+      formattingOptions: FORMATTING,
+    });
+    working = applyEdits(working, edits);
+    changed = true;
+  }
+
+  return {
+    source: working,
+    outcome: {
+      changed,
+      segments: { before: currentSegments.length, after: segmentsCount },
+      rings: { before: currentRings.length, after: ringsCount },
+    },
+  };
+}
+
+/**
+ * Resize the palettes inside the theme manifest at `manifestPath` in place.
+ * No-op (no write) if the palettes already match the requested counts.
+ */
+export function resizeThemeManifestFile(
+  manifestPath: string,
+  segmentsCount: number,
+  ringsCount: number,
+): ResizeOutcome {
+  const original = readFileSync(manifestPath, "utf8");
+  const { source, outcome } = resizeThemeManifestPalettes(
+    original,
+    segmentsCount,
+    ringsCount,
+  );
+  if (outcome.changed) {
+    writeFileSync(manifestPath, source);
+  }
+  return outcome;
+}

--- a/packages/techradar/bin/techradar.ts
+++ b/packages/techradar/bin/techradar.ts
@@ -26,6 +26,7 @@ import {
 import { applyMechanicalRenames } from "./migrateApply";
 import { detectAll, type Finding } from "./migrateDetect";
 import { extractThemeFromConfig, type ThemeMode } from "./migrateThemes";
+import { resizeThemeManifestFile } from "./resizeThemePalette";
 import { sanitizeShadowTsconfig } from "./sanitizeShadowTsconfig";
 
 // ---------------------------------------------------------------------------
@@ -288,6 +289,8 @@ function scaffoldCustomTheme(
   slug: string,
   label: string,
   themesSourceDir: string,
+  segmentsCount: number,
+  ringsCount: number,
 ): void {
   const target = join(CWD, "themes", slug);
   if (existsSync(target)) {
@@ -314,7 +317,33 @@ function scaffoldCustomTheme(
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
   }
+  resizeScaffoldedThemeManifest(manifestPath, segmentsCount, ringsCount, slug);
   consola.success(`Created themes/${slug}/ (from .example/)`);
+}
+
+function resizeScaffoldedThemeManifest(
+  manifestPath: string,
+  segmentsCount: number,
+  ringsCount: number,
+  themeId: string,
+): void {
+  if (!existsSync(manifestPath)) return;
+  try {
+    const outcome = resizeThemeManifestFile(
+      manifestPath,
+      segmentsCount,
+      ringsCount,
+    );
+    if (outcome.changed) {
+      consola.info(
+        `themes/${themeId}/: resized palette to segments=${outcome.segments.after} (was ${outcome.segments.before}), rings=${outcome.rings.after} (was ${outcome.rings.before})`,
+      );
+    }
+  } catch (err) {
+    consola.warn(
+      `themes/${themeId}/: could not resize palette (${(err as Error).message}); runtime cycling will still render correctly.`,
+    );
+  }
 }
 
 async function bootstrap(
@@ -368,18 +397,28 @@ async function bootstrap(
   const themesSourceDir = join(SOURCE_DIR, "data", "themes");
   if (existsSync(themesSourceDir)) {
     for (const theme of answers.themes) {
-      scaffold(
+      const created = scaffold(
         join(CWD, "themes", theme),
         join(themesSourceDir, theme),
         `themes/${theme}/`,
         true,
       );
+      if (created) {
+        resizeScaffoldedThemeManifest(
+          join(CWD, "themes", theme, "manifest.jsonc"),
+          answers.segments.length,
+          answers.rings.length,
+          theme,
+        );
+      }
     }
     if (answers.customTheme) {
       scaffoldCustomTheme(
         answers.customTheme.slug,
         answers.customTheme.label,
         themesSourceDir,
+        answers.segments.length,
+        answers.rings.length,
       );
     }
   }

--- a/packages/techradar/scripts/theme/__tests__/scanner.test.ts
+++ b/packages/techradar/scripts/theme/__tests__/scanner.test.ts
@@ -125,10 +125,40 @@ describe("scanThemes", () => {
     );
   });
 
-  it("still validates radar array lengths", () => {
+  it("accepts a palette shorter than the configured taxonomy (runtime cycles)", () => {
     writeTheme(tmpDir, "my-theme");
-    expect(() =>
-      scanThemes({ ...BASE_OPTS, builtinDir: tmpDir, segmentsCount: 3 }),
-    ).toThrow(/radar\.segments has 4 entries but config\.segments has 3/);
+    const infoSpy = vi.spyOn(consola, "info").mockImplementation(() => {});
+    const result = scanThemes({
+      ...BASE_OPTS,
+      builtinDir: tmpDir,
+      segmentsCount: 7,
+      ringsCount: 7,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].radar.segments).toHaveLength(4);
+    expect(infoSpy).toHaveBeenCalled();
+    infoSpy.mockRestore();
+  });
+
+  it("accepts a palette longer than the configured taxonomy (extras unused)", () => {
+    writeTheme(tmpDir, "my-theme");
+    const result = scanThemes({
+      ...BASE_OPTS,
+      builtinDir: tmpDir,
+      segmentsCount: 2,
+      ringsCount: 2,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].radar.segments).toHaveLength(4);
+  });
+
+  it("rejects an empty palette via the Zod schema", () => {
+    writeTheme(tmpDir, "my-theme", {
+      ...VALID_THEME_JSON,
+      radar: { segments: [], rings: [] },
+    });
+    expect(() => scanThemes({ ...BASE_OPTS, builtinDir: tmpDir })).toThrow(
+      /too small|>=1/i,
+    );
   });
 });

--- a/packages/techradar/scripts/theme/scanner.ts
+++ b/packages/techradar/scripts/theme/scanner.ts
@@ -66,15 +66,30 @@ function loadThemeJson(
 
   const themeJson = parseResult.data;
 
-  if (themeJson.radar.segments.length !== segmentsCount) {
-    throw new Error(
-      `theme '${id}': radar.segments has ${themeJson.radar.segments.length} entries but config.segments has ${segmentsCount}`,
+  // Palette length and config taxonomy length are decoupled by design.
+  // `resolveTheme()` in src/lib/theme/schema.ts cycles palettes via
+  // `palette[index % palette.length]` and extends arrays to
+  // `Math.max(manifest.length, configCount)`, so a palette of N entries
+  // renders a radar with M segments/rings (M ≠ N) without error — the
+  // built-ins ship a fixed 4-entry palette intentionally. Zod already
+  // enforces `.min(1)` on each palette, which is the only hard invariant
+  // the renderer needs. We log a friendly hint when palette < count so
+  // consumers know their colours will cycle, but never block the build.
+  if (
+    themeJson.radar.segments.length > 0 &&
+    themeJson.radar.segments.length < segmentsCount
+  ) {
+    consola.info(
+      `[theme-scanner] theme '${id}': radar.segments has ${themeJson.radar.segments.length} entries for ${segmentsCount} segments — colours will cycle (palette[index % ${themeJson.radar.segments.length}]).`,
     );
   }
 
-  if (themeJson.radar.rings.length !== ringsCount) {
-    throw new Error(
-      `theme '${id}': radar.rings has ${themeJson.radar.rings.length} entries but config.rings has ${ringsCount}`,
+  if (
+    themeJson.radar.rings.length > 0 &&
+    themeJson.radar.rings.length < ringsCount
+  ) {
+    consola.info(
+      `[theme-scanner] theme '${id}': radar.rings has ${themeJson.radar.rings.length} entries for ${ringsCount} rings — colours will cycle (palette[index % ${themeJson.radar.rings.length}]).`,
     );
   }
 


### PR DESCRIPTION
## Summary

Scaffolding a new project via `npm create @porscheofficial/techradar` and
choosing anything other than 4 segments (e.g. the user-reported case of 5
custom segments) crashed on the very first `npm run dev` with:

```
ERROR theme 'neutral': radar.segments has 4 entries but config.segments has 5
    at loadThemeJson (scripts/theme/scanner.ts:70:11)
```

Every built-in theme's `manifest.jsonc` ships a hardcoded 4-entry
`radar.segments` / `radar.rings` palette, and the build-time theme
scanner enforced strict length equality between the palette and the
user's `config.json` taxonomy. That directly contradicted the runtime
contract: `paletteAt()` (`src/lib/theme/schema.ts`) cycles via
`palette[index % palette.length]` and `resolveTheme()` extends arrays
with `Math.max(manifest.length, configCount)`, so the renderer has
always handled any palette length gracefully. This PR fixes both ends of
the contradiction so the issue cannot resurface from either direction.

## Changes

- **Scanner (`packages/techradar/scripts/theme/scanner.ts`)** — drop the
  strict length-equality checks. Zod's existing `.min(1)` on
  `radarPaletteSchema` remains the sole hard invariant. Log a friendly
  `consola.info` hint when a palette is shorter than the configured
  count so consumers know their colours will cycle, but never block the
  build. A block comment documents the cross-file runtime contract so
  the strict check does not get re-added.
- **Scaffold-time resize (new `packages/techradar/bin/resizeThemePalette.ts` + wiring in `packages/techradar/bin/techradar.ts`)** —
  after copying any built-in theme during `init`, resize the manifest's
  palette in place to match the user's segments/rings count by cycling
  the existing colours. Uses `jsonc-parser`'s `modify` + `applyEdits`
  so comments and formatting in `manifest.jsonc` (notably the
  `.example/` template) survive untouched. The bootstrap loop only
  resizes on fresh scaffold (`scaffold(...) === true`), so re-running
  `init` never overwrites a consumer-edited theme. Resize failures
  degrade to a `consola.warn` — runtime cycling will still render
  correctly.
- **Tests**:
  - New `packages/techradar/bin/__tests__/resizeThemePalette.test.ts`
    (14 tests) covers grow, shrink, no-op, both palettes, comment
    preservation, unrelated-field preservation, and every error path
    (invalid counts, missing radar, non-array fields, empty source,
    parse errors), plus the file-mode no-op-when-unchanged optimisation.
  - `packages/techradar/scripts/theme/__tests__/scanner.test.ts`: the
    obsolete `'still validates radar array lengths'` test asserted the
    wrong direction (4-entry palette vs 3-entry config) and is replaced
    by three new tests covering shorter palette (passes with info),
    longer palette (passes silently, extras unused), and empty palette
    (still rejected by Zod).

No `docs/HARNESS.md` or ADR update needed: this PR touches build-time
data ingestion (`scripts/theme/`) and the scaffolder CLI (`bin/`), not a
harness sensor or `pnpm run check:*` script.

## Why no test caught it before

- `initFlow.test.ts` only tested helpers (`parseSegmentsCsv`,
  `buildConfigJson`, `generateStarterBlips`) in isolation, never the
  bootstrap + buildThemes pipeline.
- `init-theme-copy.test.ts` is a source-shape regex, doesn't execute
  scaffold.
- The scanner's existing length test covered the wrong direction with
  4-segment fixtures.
- The package's own dev data uses 4 segments, so the in-tree build
  always succeeded.
- No end-to-end scaffold + `buildThemes` test existed; the new
  `resizeThemePalette.test.ts` plus the relaxed scanner tests close
  that gap.

## Verification

- Full local harness green: `lint`, `typecheck`, `test`, `check:arch`,
  `check:sec`, `check:quality`, `check:a11y`, `check:build` — all exit 0.
- Targeted tests: 694 (techradar) + 75 (create-techradar) passing,
  including the 17 new / replaced palette-resize and scanner cases.
- Quality coverage: Statements 84.16% · Branches 78.56% · Functions
  84.01% · Lines 85.96%.
- Bundle budget: 691.9 KB vs 690.3 KB baseline (+0.24%, within budget).

## Notes for reviewers

- I considered splitting into two commits (A: relax scanner, B: scaffold
  resize) but kept them atomic because either change alone leaves the
  product temporarily inconsistent: A without B = consumers still ship
  pre-cycled themes from scaffold; B without A = post-scaffold
  config-drift (user later edits `config.json` to add a 6th segment)
  still crashes the build. The two changes together describe one fix.
- The new `bin/resizeThemePalette.ts` is intentionally pure /
  file-system-agnostic at its core (`resizeThemeManifestPalettes`) and
  testable without touching disk; the thin `resizeThemeManifestFile`
  wrapper is what `bin/techradar.ts` calls.