### PR TITLE
fix(techradar): support arbitrary segment counts in radar layout

### DIFF
--- a/packages/techradar/scripts/positioner.ts
+++ b/packages/techradar/scripts/positioner.ts
@@ -1,4 +1,5 @@
 import consola from "consola";
+import { computeSegmentStartAngle } from "../src/lib/radarGeometry";
 import type { Ring, Segment } from "../src/lib/types";
 
 type Position = [x: number, y: number];
@@ -21,9 +22,10 @@ export default class Positioner {
     this.sweep = segments.length > 0 ? 360 / segments.length : 90;
 
     segments.forEach((segment) => {
-      // Position 1 starts at 270°, each subsequent advances by sweep degrees
-      this.segmentAngles[segment.id] =
-        (270 + (segment.position - 1) * this.sweep) % 360;
+      this.segmentAngles[segment.id] = computeSegmentStartAngle(
+        segment.position,
+        segments.length,
+      );
     });
 
     rings.forEach((ring, index) => {

--- a/packages/techradar/src/components/Radar/Chart.tsx
+++ b/packages/techradar/src/components/Radar/Chart.tsx
@@ -11,7 +11,11 @@ import {
 import { Blip } from "@/components/Radar/Blip";
 import { getItemChangeDirection, getToggle } from "@/lib/data";
 import { useRadarHighlight } from "@/lib/RadarHighlightContext";
-import { describeFilledArc } from "@/lib/radarGeometry";
+import {
+  computeSegmentStartAngle,
+  describeFilledArc,
+  describePieWedge,
+} from "@/lib/radarGeometry";
 import { useTheme } from "@/lib/ThemeContext";
 import { segmentForegroundVar } from "@/lib/theme/schema";
 import { Flag, type Item, type Ring, type Segment } from "@/lib/types";
@@ -161,12 +165,8 @@ const ChartInner: FC<ChartProps> = ({
     return map;
   }, [items]);
 
-  // Compute start angle for each segment position (1-indexed).
-  // Position 1 starts at 270° (top-left for 4 segments), each subsequent
-  // segment advances by `sweep` degrees clockwise.
-  const getStartAngle = (position: number): number => {
-    return (270 + (position - 1) * sweep) % 360;
-  };
+  const getStartAngle = (position: number): number =>
+    computeSegmentStartAngle(position, numSegments);
 
   const polarToCartesian = (
     radius: number,
@@ -208,17 +208,14 @@ const ChartInner: FC<ChartProps> = ({
   const renderGlow = (position: number, color: string) => {
     const gradientId = `glow-${position}`;
     const startAngle = getStartAngle(position);
-    const midAngle = startAngle + sweep / 2;
-    const midRad = ((midAngle - 90) * Math.PI) / 180;
-
-    const dirX = Math.cos(midRad);
-    const dirY = Math.sin(midRad);
-
-    // Rect from SVG edge to radar center; gradient radiates from center outward
-    const rectW = viewBoxCenter;
-    const rectH = viewBoxCenter;
-    const rectX = dirX >= 0 ? viewBoxCenter : 0;
-    const rectY = dirY >= 0 ? viewBoxCenter : 0;
+    const endAngle = startAngle + sweep;
+    const wedgeD = describePieWedge(
+      viewBoxCenter,
+      viewBoxCenter,
+      center,
+      startAngle,
+      endAngle,
+    );
     return (
       <>
         <defs>
@@ -233,13 +230,7 @@ const ChartInner: FC<ChartProps> = ({
             <stop offset="100%" stopColor={color} stopOpacity={0} />
           </radialGradient>
         </defs>
-        <rect
-          width={rectW}
-          height={rectH}
-          x={rectX}
-          y={rectY}
-          fill={`url(#${gradientId})`}
-        />
+        <path d={wedgeD} fill={`url(#${gradientId})`} />
       </>
     );
   };
@@ -289,11 +280,8 @@ const ChartInner: FC<ChartProps> = ({
   };
 
   const renderRingLabels = () => {
-    // Place ring labels along each segment boundary line.
-    // For N segments we place labels on the first boundary (position 1 start angle).
-    // We also place a mirrored set on the opposite boundary for readability.
-    const labelAngle = getStartAngle(1);
-    const oppositeAngle = (labelAngle + 180) % 360;
+    const labelAngle = 270;
+    const oppositeAngle = 90;
 
     return rings.map((ring, index) => {
       const outerRadius = ring.radius || 1;

--- a/packages/techradar/src/components/Radar/__tests__/Chart.flexible-segments.test.tsx
+++ b/packages/techradar/src/components/Radar/__tests__/Chart.flexible-segments.test.tsx
@@ -89,7 +89,9 @@ describe("Chart with flexible segment counts", () => {
       const segmentGroups = container.querySelectorAll("g[data-segment]");
       expect(segmentGroups).toHaveLength(n);
 
-      const arcPaths = container.querySelectorAll("g[data-segment] > path");
+      const arcPaths = container.querySelectorAll(
+        "g[data-segment] > path[data-key]",
+      );
       expect(arcPaths).toHaveLength(n * rings.length);
 
       const gradients = container.querySelectorAll("radialGradient");
@@ -111,7 +113,7 @@ describe("Chart with flexible segment counts", () => {
     const { container } = render(
       <Chart size={800} segments={segments} rings={rings} items={items} />,
     );
-    const firstArc = container.querySelector("g[data-segment] path");
+    const firstArc = container.querySelector("g[data-segment] path[data-key]");
     expect(firstArc?.getAttribute("d")).toMatch(/A \d+ \d+ 0 1 0/);
   });
 
@@ -120,7 +122,24 @@ describe("Chart with flexible segment counts", () => {
     const { container } = render(
       <Chart size={800} segments={segments} rings={rings} items={items} />,
     );
-    const firstArc = container.querySelector("g[data-segment] path");
+    const firstArc = container.querySelector("g[data-segment] path[data-key]");
     expect(firstArc?.getAttribute("d")).toMatch(/A \d+ \d+ 0 0 0/);
+  });
+
+  it("places ring labels on the horizontal axis regardless of segment count", () => {
+    const segments = makeSegments(5);
+    const { container } = render(
+      <Chart size={800} segments={segments} rings={rings} items={items} />,
+    );
+    const ringLabels = Array.from(container.querySelectorAll("text")).filter(
+      (node) => {
+        const text = node.textContent ?? "";
+        return text === "Adopt" || text === "Trial";
+      },
+    );
+    expect(ringLabels.length).toBeGreaterThan(0);
+    for (const label of ringLabels) {
+      expect(Number(label.getAttribute("y"))).toBeCloseTo(472, 5);
+    }
   });
 });

--- a/packages/techradar/src/components/SegmentRadar/SegmentChart.tsx
+++ b/packages/techradar/src/components/SegmentRadar/SegmentChart.tsx
@@ -3,7 +3,11 @@ import { type FC, memo, useMemo } from "react";
 import { Blip } from "@/components/Radar/Blip";
 import { getItemChangeDirection, getToggle } from "@/lib/data";
 import { useRadarHighlight } from "@/lib/RadarHighlightContext";
-import { describeFilledArc } from "@/lib/radarGeometry";
+import {
+  computeSegmentStartAngle,
+  describeFilledArc,
+  describePieWedge,
+} from "@/lib/radarGeometry";
 import { useTheme } from "@/lib/ThemeContext";
 import { segmentForegroundVar } from "@/lib/theme/schema";
 import { Flag, type Item, type Ring, type Segment } from "@/lib/types";
@@ -49,9 +53,8 @@ const SegmentChartInner: FC<SegmentChartProps> = ({
   const sweep = numSegments > 0 ? 360 / numSegments : 90;
   const position = segment.position;
 
-  const getStartAngle = (pos: number): number => {
-    return (270 + (pos - 1) * sweep) % 360;
-  };
+  const getStartAngle = (pos: number): number =>
+    computeSegmentStartAngle(pos, numSegments);
 
   const startAngle = getStartAngle(position);
   const endAngle = startAngle + sweep;
@@ -135,14 +138,13 @@ const SegmentChartInner: FC<SegmentChartProps> = ({
 
   const renderGlow = () => {
     const gradientId = `qc-glow-${position}`;
-    const midRad = toRad(midAngle);
-    const dirX = Math.cos(midRad);
-    const dirY = Math.sin(midRad);
-
-    const rectW = center;
-    const rectH = center;
-    const rectX = dirX >= 0 ? center : 0;
-    const rectY = dirY >= 0 ? center : 0;
+    const wedgeD = describePieWedge(
+      center,
+      center,
+      center,
+      startAngle,
+      endAngle,
+    );
 
     return (
       <>
@@ -158,13 +160,7 @@ const SegmentChartInner: FC<SegmentChartProps> = ({
             <stop offset="100%" stopColor={segmentColor} stopOpacity={0} />
           </radialGradient>
         </defs>
-        <rect
-          width={rectW}
-          height={rectH}
-          x={rectX}
-          y={rectY}
-          fill={`url(#${gradientId})`}
-        />
+        <path d={wedgeD} fill={`url(#${gradientId})`} />
       </>
     );
   };

--- a/packages/techradar/src/lib/__tests__/radarGeometry.test.ts
+++ b/packages/techradar/src/lib/__tests__/radarGeometry.test.ts
@@ -1,4 +1,9 @@
-import { describeFilledArc, polarToCartesian } from "@/lib/radarGeometry";
+import {
+  computeSegmentStartAngle,
+  describeFilledArc,
+  describePieWedge,
+  polarToCartesian,
+} from "@/lib/radarGeometry";
 
 describe("polarToCartesian", () => {
   it("places 0° at the top of the circle", () => {
@@ -88,5 +93,78 @@ describe("describeFilledArc", () => {
     const outerEndXIdx = tokens.indexOf("A") + 6;
     expect(tokens[outerEndXIdx]).toBe("100");
     expect(tokens[outerEndXIdx + 1]).toBe("0");
+  });
+});
+
+describe("describePieWedge", () => {
+  it("starts at the centre, traces out to the arc, and closes with Z", () => {
+    const d = describePieWedge(100, 100, 50, 0, 90);
+    const tokens = d.split(" ");
+    expect(tokens[0]).toBe("M");
+    expect(tokens[1]).toBe("100");
+    expect(tokens[2]).toBe("100");
+    expect(tokens[3]).toBe("L");
+    expect(d).toContain("A 50 50");
+    expect(d).toMatch(/ Z$/);
+  });
+
+  it("covers a six-segment top wedge that straddles 0°/360° as one continuous shape", () => {
+    // Six segments => sweep 60°. The "AI" segment in the user-reported bug
+    // spans 330°→390° (i.e. midAngle = 0° / straight up). The pie wedge must
+    // include both the upper-left point (at 330°) and the upper-right point
+    // (at 30°) — proving the glow no longer collapses onto one half-plane.
+    const cx = 100;
+    const cy = 100;
+    const r = 50;
+    const d = describePieWedge(cx, cy, r, 330, 390);
+
+    const left = polarToCartesian(cx, cy, r, 330);
+    const right = polarToCartesian(cx, cy, r, 390);
+
+    expect(d).toContain(`L ${left.x} ${left.y}`);
+    expect(d).toContain(`${right.x} ${right.y} Z`);
+    expect(left.x).toBeLessThan(cx);
+    expect(right.x).toBeGreaterThan(cx);
+  });
+});
+
+describe("computeSegmentStartAngle", () => {
+  it("keeps the historical 4-segment layout (boundaries on cardinal axes)", () => {
+    expect(computeSegmentStartAngle(1, 4)).toBe(270);
+    expect(computeSegmentStartAngle(2, 4)).toBe(0);
+    expect(computeSegmentStartAngle(3, 4)).toBe(90);
+    expect(computeSegmentStartAngle(4, 4)).toBe(180);
+  });
+
+  it("places a boundary at 12 o'clock for even segment counts (N=6)", () => {
+    const start = computeSegmentStartAngle(1, 6);
+    expect((start + 60) % 360).toBe(0);
+  });
+
+  it("centres segment 1 at 12 o'clock for odd segment counts (N=5)", () => {
+    const sweep = 360 / 5;
+    const start = computeSegmentStartAngle(1, 5);
+    const mid = (start + sweep / 2) % 360;
+    expect(mid).toBe(0);
+  });
+
+  it("places a vertical boundary at the bottom for N=5", () => {
+    const sweep = 360 / 5;
+    const boundaries = [1, 2, 3, 4, 5].flatMap((p) => [
+      computeSegmentStartAngle(p, 5),
+      (computeSegmentStartAngle(p, 5) + sweep) % 360,
+    ]);
+    expect(boundaries).toContain(180);
+  });
+
+  it("centres segment 1 at 12 o'clock for N=3", () => {
+    const sweep = 360 / 3;
+    const start = computeSegmentStartAngle(1, 3);
+    const mid = (start + sweep / 2) % 360;
+    expect(mid).toBe(0);
+  });
+
+  it("returns 0 when there are no segments", () => {
+    expect(computeSegmentStartAngle(1, 0)).toBe(0);
   });
 });

--- a/packages/techradar/src/lib/radarGeometry.ts
+++ b/packages/techradar/src/lib/radarGeometry.ts
@@ -7,8 +7,7 @@ interface Point {
  * Convert polar coordinates to Cartesian coordinates relative to a center point.
  *
  * Angles are measured in degrees. 0° points to the top of the circle (12 o'clock),
- * 90° to the right (3 o'clock), 180° to the bottom, 270° to the left — matching
- * the radar's segment positioning convention.
+ * 90° to the right (3 o'clock), 180° to the bottom, 270° to the left.
  */
 export function polarToCartesian(
   cx: number,
@@ -73,6 +72,73 @@ export function describeFilledArc(
     1,
     innerEnd.x,
     innerEnd.y,
+    "Z",
+  ].join(" ");
+}
+
+/**
+ * Build an SVG path `d` string for a filled pie-wedge (sector) — i.e. a
+ * triangle-like slice from `(cx, cy)` out along `startAngle`, around the
+ * outer arc to `endAngle`, and back to the centre.
+ *
+ * This is the correct clipping shape for a per-segment radial glow: it
+ * follows the segment's actual angular bounds for any segment count,
+ * unlike an axis-aligned half-rect which only happens to match 4-segment
+ * layouts whose mid-directions are pure diagonals.
+ */
+/**
+ * Compute the start angle (in degrees, 0° = top, increasing clockwise) of a
+ * radar segment given its 1-indexed `position` and the total `numSegments`.
+ *
+ * Parity-aware orientation:
+ * - Even N: a segment *boundary* sits at 12 o'clock — segment 1 starts at
+ *   `(360 - sweep) % 360`, so e.g. for N=4 (sweep=90°) position 1 starts at
+ *   270° (left), preserving the historical 4-segment layout where boundaries
+ *   land on the cardinal axes.
+ * - Odd N: segment 1 is *centred* at 12 o'clock — its start angle is
+ *   `(360 - sweep / 2) % 360`. This keeps odd-segment radars visually
+ *   symmetric about the vertical axis (e.g. N=5 puts the top segment
+ *   straight up with a vertical boundary at the bottom).
+ */
+export function computeSegmentStartAngle(
+  position: number,
+  numSegments: number,
+): number {
+  if (numSegments <= 0) return 0;
+  const sweep = 360 / numSegments;
+  const firstStart =
+    numSegments % 2 === 0 ? (360 - sweep) % 360 : (360 - sweep / 2) % 360;
+  return (firstStart + (position - 1) * sweep) % 360;
+}
+
+export function describePieWedge(
+  cx: number,
+  cy: number,
+  outerRadius: number,
+  startAngle: number,
+  endAngle: number,
+): string {
+  const sweep = endAngle - startAngle;
+  const largeArcFlag = sweep > 180 ? 1 : 0;
+
+  const arcStart = polarToCartesian(cx, cy, outerRadius, startAngle);
+  const arcEnd = polarToCartesian(cx, cy, outerRadius, endAngle);
+
+  return [
+    "M",
+    cx,
+    cy,
+    "L",
+    arcStart.x,
+    arcStart.y,
+    "A",
+    outerRadius,
+    outerRadius,
+    0,
+    largeArcFlag,
+    1,
+    arcEnd.x,
+    arcEnd.y,
     "Z",
   ].join(" ");
 }


### PR DESCRIPTION
## Summary

The radar visualisation assumed a 4-segment layout in three places, so picking 5 or 6 segments produced visibly broken output: per-segment glows clipped to half a wedge near the vertical axis, the top of the radar not aligned to a sensible cardinal direction for odd N, and build-time blip placement landing in the wrong wedge once orientation changed. This PR makes the radar layout work for any reasonable segment count (1–6+), keeps the existing 4-segment Porsche layout pixel-identical, and pins the new behaviour with regression tests.

## Changes

- **Glow now follows the wedge.** New geometry helper `describePieWedge(cx, cy, r, startAngle, endAngle)` in `src/lib/radarGeometry.ts`. `Chart.tsx` and `SegmentChart.tsx` `renderGlow()` fill the radial gradient into a true sector path instead of one of four axis-aligned half-rectangles. Old code only matched real wedges when `cos(midAngle)` and `sin(midAngle)` were both non-zero — i.e. exact diagonals — so for N=5 or N=6 the segments whose mid-angle was 0° or 180° collapsed to half a rectangle.
- **Parity-aware orientation.** New helper `computeSegmentStartAngle(position, numSegments)` encodes the rule: even N → boundary at 12 o'clock (preserves existing 4-segment layout exactly), odd N → segment 1 centred at 12 o'clock. `Chart.tsx`, `SegmentChart.tsx`, and `scripts/positioner.ts` all route through it, so render and build-time blip placement stay in lockstep.
- **Ring labels stay horizontal on the main radar.** `HOLD/ASSESS/TRIAL/ADOPT` are now pinned to 270°/90° regardless of segment count, so they remain readable for any N. The segment detail page intentionally keeps its per-segment label orientation (the user verified this is correct).
- **Tests** pin: N=4 layout (regression), N=5 segment-1 mid-angle at top, N=6 boundary at top, the new pie-wedge path geometry, and horizontal ring labels rendered for N=5.

No public API or config schema changes — `data/config.default.json` is untouched.

## Verification

- Local harness — all green:
  - `pnpm run lint`, `pnpm run typecheck`
  - `pnpm run test` → 735 passed in techradar (incl. 9 new), 75 passed in create-techradar
  - `pnpm run check:arch`, `pnpm run check:sec`, `pnpm run check:quality`, `pnpm run check:a11y`, `pnpm run check:build`
- Manually verified visually on the dev server with N=4 (Porsche default), N=5, and N=6 configs: glow fills the wedge, segment 1 is centred at 12 o'clock for odd N, boundary sits at 12 o'clock for even N, ring labels stay horizontal, and blips land inside their declared segment.