### PR TITLE
fix(deps): remove duplicate tinyexec key from broken lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5631,10 +5631,6 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
-
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -11634,8 +11630,6 @@ snapshots:
   tinyexec@0.3.2: {}
 
   tinyexec@1.1.2: {}
-
-  tinyexec@1.2.4: {}
 
   tinyexec@1.2.4: {}
 


### PR DESCRIPTION
## Summary

The latest dependabot merge left `pnpm-lock.yaml` with the mapping key `tinyexec@1.2.4` duplicated, producing an invalid lockfile. pnpm parses the lockfile as strict YAML and rejected it with `ERR_PNPM_BROKEN_LOCKFILE (duplicated mapping key 5634:3)`, which failed the very first `pnpm install --frozen-lockfile` step and turned CI, Security, and Deploy to GitHub Pages red on `main`. This removes the redundant stanzas so the lockfile is valid again.

## Changes

- Remove the duplicate `tinyexec@1.2.4` entry from the `packages:` section (resolution + engines).
- Remove the duplicate `tinyexec@1.2.4: {}` entry from the `snapshots:` section.
- Net: 6 deletions, lockfile content otherwise unchanged.

## Verification

- `pnpm install --frozen-lockfile` now succeeds (previously `ERR_PNPM_BROKEN_LOCKFILE`).
- Local harness all green: lint, typecheck, test, check:arch, check:sec, check:quality, check:a11y, check:build.

## Notes for reviewers

Pure lockfile repair of a merge artifact — no dependency version changes. The removed lines were byte-identical duplicates of the retained entries.