### PR TITLE
ci: use npm publish directly for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -90,7 +90,9 @@ jobs:
       # Both packages are configured for OIDC Trusted Publishing on npmjs.org —
       # no NPM_TOKEN secret needed.
       - if: ${{ github.event_name == 'workflow_dispatch' || needs.release-please.outputs.techradar_release_created == 'true' }}
-        run: pnpm --filter @porscheofficial/porschedigital-technology-radar publish --no-git-checks --provenance
+        working-directory: packages/techradar
+        run: npm publish --provenance --access public
 
       - if: ${{ github.event_name == 'workflow_dispatch' || needs.release-please.outputs.create_techradar_release_created == 'true' }}
-        run: pnpm --filter @porscheofficial/create-techradar publish --no-git-checks --provenance
+        working-directory: packages/create-techradar
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

The `release-please` publish job was failing with a `404 Not Found` on PUT when trying to publish `@porscheofficial/porschedigital-technology-radar@2.2.4`. The root cause: `pnpm publish` does not reliably forward the OIDC token exchange to npm when `setup-node` has injected `NODE_AUTH_TOKEN` into the `.npmrc`. npm fell back to the empty/invalid classic token instead of acquiring an OIDC token via Trusted Publishing, causing the 404.

This was confirmed by comparing the successful `2.2.3` publish (May 21) against the failing `2.2.4` run: identical npm version (`11.5.1`), identical workflow, identical permissions — but `2.2.4` never emitted the `npm notice publish Signed provenance statement` line that `2.2.3` did. The OIDC exchange was silently skipped.

## Changes

- Replace `pnpm --filter <pkg> publish --no-git-checks --provenance` with `npm publish --provenance --access public` run from each package's `working-directory`
- This matches the documented intent already present in the workflow comment (lines 67–71: "We deliberately keep `npm publish` (not `pnpm publish`) for the publish step")

## Verification

- Local harness: lint, typecheck, test, check:arch, check:sec, check:quality, check:a11y, check:build — all green
- Compared CI logs between successful 2.2.3 publish (run 26217422618) and failing 2.2.4 publish (run 27433124137): same npm version, same workflow — difference is the missing OIDC provenance log line in the failing run
- After merging, trigger recovery via: `gh workflow run release-please.yml -f force_publish=true`

## Notes for reviewers

The `--no-git-checks` flag is no longer needed since we use `working-directory` instead of pnpm's workspace filter (pnpm's filter needs `--no-git-checks` to publish from a non-root dir; `npm publish` run directly from the package dir does not).