### PR TITLE
fix(techradar): pass configured chart size to segment radar

### DIFF
--- a/packages/techradar/src/__tests__/pages/segment/segment.test.tsx
+++ b/packages/techradar/src/__tests__/pages/segment/segment.test.tsx
@@ -17,6 +17,7 @@ const mockState = vi.hoisted(() => ({
     clearFilters: vi.fn(),
   },
   getAppName: vi.fn(),
+  getChartConfig: vi.fn(),
   getItems: vi.fn(),
   getSegment: vi.fn(),
   getSegments: vi.fn(),
@@ -113,6 +114,7 @@ vi.mock("@/lib/ThemeContext", () => ({
 
 vi.mock("@/lib/data", () => ({
   getAppName: mockState.getAppName,
+  getChartConfig: mockState.getChartConfig,
   getItems: mockState.getItems,
   getSegment: mockState.getSegment,
   getSegments: mockState.getSegments,
@@ -219,6 +221,7 @@ describe("Segment detail page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockState.getAppName.mockReturnValue("Test Radar");
+    mockState.getChartConfig.mockReturnValue({ size: 1200, blipSize: 12 });
     mockState.getSegment.mockImplementation((id: string) =>
       segments.find((entry) => entry.id === id),
     );
@@ -263,6 +266,16 @@ describe("Segment detail page", () => {
         allSegments: segments,
         rings,
         items: [items[0]], // Only featured items (React)
+      }),
+    );
+  });
+
+  it("passes the configured chart size to SegmentRadar", () => {
+    render(<SegmentPage segmentId={segment.id} />);
+
+    expect(mockState.segmentRadarProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        size: 1200,
       }),
     );
   });

--- a/packages/techradar/src/components/SegmentRadar/SegmentRadar.tsx
+++ b/packages/techradar/src/components/SegmentRadar/SegmentRadar.tsx
@@ -6,6 +6,8 @@ import { cn } from "@/lib/utils";
 import styles from "./SegmentRadar.module.scss";
 
 interface SegmentRadarProps {
+  /** Full radar size used during position generation (default 800). */
+  size?: number;
   segment: Segment;
   allSegments: Segment[];
   rings: Ring[];
@@ -14,6 +16,7 @@ interface SegmentRadarProps {
 }
 
 export const SegmentRadar: FC<SegmentRadarProps> = ({
+  size,
   segment,
   allSegments,
   rings,
@@ -41,6 +44,7 @@ export const SegmentRadar: FC<SegmentRadarProps> = ({
     >
       <SegmentChart
         className={styles.chart}
+        size={size}
         segment={segment}
         allSegments={allSegments}
         rings={rings}

--- a/packages/techradar/src/components/SegmentRadar/__tests__/SegmentRadar.test.tsx
+++ b/packages/techradar/src/components/SegmentRadar/__tests__/SegmentRadar.test.tsx
@@ -124,6 +124,7 @@ describe("SegmentRadar", () => {
 
     render(
       <SegmentRadar
+        size={1200}
         segment={segment}
         allSegments={allSegments}
         rings={rings}
@@ -158,6 +159,7 @@ describe("SegmentRadar", () => {
     expect(tooltipState.handleMouseLeave).toHaveBeenCalledTimes(1);
     expect(segmentChartMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        size: 1200,
         segment,
         allSegments,
         rings,

--- a/packages/techradar/src/pages/[segment]/index.tsx
+++ b/packages/techradar/src/pages/[segment]/index.tsx
@@ -11,6 +11,7 @@ import { SegmentRadar } from "@/components/SegmentRadar/SegmentRadar";
 import { SeoHead } from "@/components/SeoHead/SeoHead";
 import { blipSvgMap } from "@/lib/blipIcons";
 import {
+  getChartConfig,
   getItems,
   getRings,
   getSegment,
@@ -34,6 +35,7 @@ const SegmentPage: CustomPage<SegmentPageProps> = ({ segmentId }) => {
   const segment = getSegment(segmentId);
   const allSegments = getSegments();
   const rings = getRings();
+  const chartConfig = getChartConfig();
   const { setHighlight } = useRadarHighlight();
   const { theme } = useTheme();
 
@@ -147,6 +149,7 @@ const SegmentPage: CustomPage<SegmentPageProps> = ({ segmentId }) => {
               </PText>
             )}
             <SegmentRadar
+              size={chartConfig.size}
               segment={segment}
               allSegments={allSegments}
               rings={rings}


### PR DESCRIPTION
## Summary

Segment/quadrant detail pages misalign blips whenever `chart.size` is customized away from the default (800) in `data/config.json`. The main radar page correctly threads the configured size through `Radar` → `Chart`, but the segment page never passed `size` through `SegmentRadar` → `SegmentChart`, which silently fell back to a hardcoded `size = 800`. Blip coordinates are baked at build time using the real configured size, so any custom `chart.size` caused the rings/wedges/viewBox (drawn at the wrong center) to no longer line up with the blips (positioned for the real center). This PR wires the real `chart.size` through the segment page, matching the existing main-page pattern.

## Changes

- `packages/techradar/src/pages/[segment]/index.tsx`: import and call `getChartConfig()` (same pattern as `pages/index.tsx`), pass `size={chartConfig.size}` into `<SegmentRadar>`.
- `packages/techradar/src/components/SegmentRadar/SegmentRadar.tsx`: add `size?: number` to `SegmentRadarProps` and forward it to `<SegmentChart>`.
- `packages/techradar/src/components/SegmentRadar/SegmentChart.tsx`: `size = 800` remains only as a fallback default for isolated/test usage; now correctly overridden whenever a real size is supplied.
- Added/updated tests asserting size propagation through `SegmentRadar` and the segment page.

## Verification

- Local harness: lint, typecheck, test, check:arch, check:quality, check:a11y, check:build — all green.
- Manually reasoned through the fix: setting `chart.size` to a non-default value (e.g. 1200, as in the issue) now keeps segment-page rings/wedges/viewBox and blips in the same coordinate frame, matching the already-correct main radar page behavior.

## Notes for reviewers

Scoped to the #178 fix only. Pre-existing transitive-dependency CVEs surfaced by `check:sec:deps` during verification are intentionally left out of this PR and will be handled separately so this bug fix stays focused.

Closes #178