### PR TITLE
feat(techradar): add product and segment filters

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 
   "vcs": {
     "enabled": true,

--- a/packages/create-techradar/src/packageManager.ts
+++ b/packages/create-techradar/src/packageManager.ts
@@ -38,7 +38,6 @@ export function getExecCommand(
       return { command: "yarn", args: [binary, ...binaryArgs] };
     case "bun":
       return { command: "bun", args: ["x", binary, ...binaryArgs] };
-    case "npm":
     default:
       return { command: "npx", args: [binary, ...binaryArgs] };
   }

--- a/packages/techradar/README.md
+++ b/packages/techradar/README.md
@@ -140,6 +140,8 @@ All configuration lives in `data/config.json`. Any key you omit falls back to th
 | `showSearch`     | Show the search bar in the header.            | `true`  |
 | `showChart`      | Show the radar visualization on the homepage. | `true`  |
 | `showTagFilter`  | Show the tag filter below the radar.          | `true`  |
+| `showProductFilter` | Show the product filter below the radar.   | `false`  |
+| `showFilterOnSegmentPage` | Show segment-page filters and allow filtering on the segment detail page. | `false`  |
 | `showTeamFilter` | Show the team filter below the radar.         | `true`  |
 | `showBlipChange` | Show a directional arc on Changed blips indicating promotion (inward) or demotion (outward). | `true` |
 | `showDemoDisclaimer` | Show the demo-data disclaimer banner on the homepage. | `false` |
@@ -409,6 +411,8 @@ segment: languages-and-frameworks
 tags:
   - frontend
   - javascript
+products:
+  - v2
 teams:
   - web-platform
   - mobile
@@ -432,6 +436,7 @@ Supports full **Markdown** formatting.
 | `summary`  | No       | Custom summary used for meta descriptions and link previews. Falls back to the first 160 characters of the item body. |
 | `ogImage`  | No       | Custom Open Graph image. Use a relative path under `public/` (for example `/images/react-card.png`) or a full `https://...` URL. |
 | `tags`     | No       | List of tags for filtering.                                                                             |
+| `products` | No       | List of products for filtering, for example `v2` or `v3`.                                               |
 | `teams`    | No       | List of teams currently using this technology.                                                          |
 | `links`    | No       | List of external links. Each entry has a `url` (required) and optional `name`. Shown on the detail page. |
 | `featured` | No       | Set to `false` to hide from the radar chart while keeping the item in the overview. Defaults to `true`. |

--- a/packages/techradar/bin/initFlow.ts
+++ b/packages/techradar/bin/initFlow.ts
@@ -243,7 +243,7 @@ export function loadInitContext(opts: {
   const configExists = cfg !== null;
 
   const existingTitle =
-    cfg && cfg.labels && typeof cfg.labels.title === "string"
+    cfg?.labels && typeof cfg.labels.title === "string"
       ? cfg.labels.title
       : null;
 
@@ -289,7 +289,7 @@ export function defaultAnswers(
   ctx: InitContext,
   basenameDir: string,
 ): InitAnswers {
-  const title = ctx.existingTitle ?? titleCase(basenameDir) + " Tech Radar";
+  const title = ctx.existingTitle ?? `${titleCase(basenameDir)} Tech Radar`;
 
   const rings = ctx.existingRings ?? STANDARD_RINGS;
   const segments = ctx.existingSegments ?? STANDARD_SEGMENTS;

--- a/packages/techradar/bundle-budget.json
+++ b/packages/techradar/bundle-budget.json
@@ -1,6 +1,6 @@
 {
   "$schema": "Hand-edited bundle thresholds. Bump only when a deliberate cost is justified.",
-  "maxTotalJsBytes": 2700000,
-  "maxTotalCssBytes": 76000,
+  "maxTotalJsBytes": 2710000,
+  "maxTotalCssBytes": 76500,
   "maxChunkBytes": 293000
 }

--- a/packages/techradar/bundle-budget.json
+++ b/packages/techradar/bundle-budget.json
@@ -1,6 +1,6 @@
 {
   "$schema": "Hand-edited bundle thresholds. Bump only when a deliberate cost is justified.",
   "maxTotalJsBytes": 2710000,
-  "maxTotalCssBytes": 76500,
+  "maxTotalCssBytes": 77000,
   "maxChunkBytes": 293000
 }

--- a/packages/techradar/data/about.md
+++ b/packages/techradar/data/about.md
@@ -17,7 +17,7 @@ Every entry on the radar is a **blip**. Each blip has two coordinates:
     - **Assess**: interesting; explore in spikes or proofs of concept.
     - **Hold**: do not start new work with this; migrate away when practical.
 
-Click a blip to open its detail page with the full description, tags, teams, links, and a complete revision history. Use the **search** and **filter** controls to narrow things down by name, tag, team, or status. The **changelog** shows what moved between releases at a glance.
+Click a blip to open its detail page with the full description, tags, products, teams, links, and a complete revision history. Use the **search** and **filter** controls to narrow things down by name, tag, product, team, or status. The **changelog** shows what moved between releases at a glance.
 
 The structure of the radar (segments, rings, labels, colors, branding) is fully configurable per instance and may evolve over time.
 
@@ -38,7 +38,7 @@ The Technology Radar Generator is an open-source tool for teams who want their o
 - 🌗 **Theme × mode** — light/dark variants where the theme provides them, plus header toggle and Spotlight controls
 - 📡 **Radar visualization** — interactive overview with segment and ring layout
 - 📄 **Technology detail pages** — each entry gets its own page with full context
-- 🔍 **Search and filters** — find technologies by name, tag, team, or status
+- 🔍 **Search and filters** — find technologies by name, tag, product, team, or status
 - 📜 **Revision history** — track how assessments change across releases
 - 📋 **Changelog** — see what moved between releases at a glance
 - 🖼️ **Open Graph images** — every radar entry gets a shareable preview card

--- a/packages/techradar/data/config.default.json
+++ b/packages/techradar/data/config.default.json
@@ -8,6 +8,8 @@
     "showSearch": true,
     "showChart": true,
     "showTagFilter": true,
+    "showProductFilter": false,
+    "showFilterOnSegmentPage": false,
     "showTeamFilter": true,
     "showBlipChange": true,
     "showDemoDisclaimer": false,

--- a/packages/techradar/data/themes/.example/manifest.jsonc
+++ b/packages/techradar/data/themes/.example/manifest.jsonc
@@ -194,6 +194,11 @@
       "light": "#0047FF",
       "dark": "#88B5FF"
     },
+    // Pill for products (free-form taxonomy on products).
+    "product": {
+      "light": "#E11D48",
+      "dark": "#FB7185"
+    },
     // Pill for team attribution. Usually a warm secondary brand color.
     "team": {
       "light": "#C45A00",

--- a/packages/techradar/data/themes/blueprint/manifest.jsonc
+++ b/packages/techradar/data/themes/blueprint/manifest.jsonc
@@ -26,6 +26,7 @@
   "chips": {
     "status": "#3B5A86",
     "tag": "#1565C0",
+    "product": "#E11D48",
     "team": "#B85C00",
     "team-added": "#2E7D32",
     "team-removed": "#C62828"

--- a/packages/techradar/data/themes/matrix/manifest.jsonc
+++ b/packages/techradar/data/themes/matrix/manifest.jsonc
@@ -25,6 +25,7 @@
   "chips": {
     "status": "#7BC78F",
     "tag": "#39FF14",
+    "product": "#E11D48",
     "team": "#00FF66",
     "team-added": "#A6FF4D",
     "team-removed": "#FF5555"

--- a/packages/techradar/data/themes/neutral/manifest.jsonc
+++ b/packages/techradar/data/themes/neutral/manifest.jsonc
@@ -73,6 +73,10 @@
       "light": "#2563EB",
       "dark": "#60A5FA"
     },
+    "product": {
+      "light": "#E11D48",
+      "dark": "#FB7185"
+    },
     "team": {
       "light": "#D97706",
       "dark": "#FBBF24"

--- a/packages/techradar/data/themes/porsche-heritage/manifest.jsonc
+++ b/packages/techradar/data/themes/porsche-heritage/manifest.jsonc
@@ -50,6 +50,8 @@
     "status": { "light": "#6B6D70", "dark": "#88898C" },
     // Riviera Blue for tags — the flagship special-order shade.
     "tag": { "light": "#0078C8", "dark": "#3DA0E0" },
+    // Guards Red for products — the signature Porsche highlight color.
+    "product": { "light": "#E11D48", "dark": "#FB7185" },
     // Lava Orange for teams — modern PTS hero color.
     "team": { "light": "#C45A00", "dark": "#E16C0B" },
     // Acid Green — the signature GT caliper green.

--- a/packages/techradar/data/themes/porsche/manifest.jsonc
+++ b/packages/techradar/data/themes/porsche/manifest.jsonc
@@ -70,6 +70,10 @@
       "light": "#2762EC",
       "dark": "#1372D6"
     },
+    "product": {
+      "light": "#E11D48",
+      "dark": "#FB7185"
+    },
     "team": {
       "light": "#C45A00",
       "dark": "#DB6F1F"

--- a/packages/techradar/data/themes/solarized/manifest.jsonc
+++ b/packages/techradar/data/themes/solarized/manifest.jsonc
@@ -70,6 +70,10 @@
       "light": "#268BD2",
       "dark": "#268BD2"
     },
+    "product": {
+      "light": "#E11D48",
+      "dark": "#FB7185"
+    },
     "team": {
       "light": "#CB4B16",
       "dark": "#CB4B16"

--- a/packages/techradar/data/themes/synthwave/manifest.jsonc
+++ b/packages/techradar/data/themes/synthwave/manifest.jsonc
@@ -70,6 +70,10 @@
       "light": "#0891B2",
       "dark": "#05D9E8"
     },
+    "product": {
+      "light": "#E11D48",
+      "dark": "#FB7185"
+    },
     "team": {
       "light": "#C724B1",
       "dark": "#FF2A6D"

--- a/packages/techradar/scripts/__tests__/buildData.test.ts
+++ b/packages/techradar/scripts/__tests__/buildData.test.ts
@@ -854,10 +854,11 @@ describe("buildData", () => {
       expect(revisions[2]).toMatchObject({ removedTeams: ["alpha"] });
     });
 
-    it("collects unique releases and tags", () => {
+    it("collects unique releases, tags, and products", () => {
       const items: Item[] = [
         createItem({
           tags: ["frontend", "language"],
+          products: ["v2"],
           revisions: [
             createRevision({ release: "2024-01" }),
             createRevision({ release: "2024-03" }),
@@ -867,6 +868,7 @@ describe("buildData", () => {
           id: "item-2",
           title: "Item 2",
           tags: ["frontend", "runtime"],
+          products: ["v2", "v3"],
           revisions: [createRevision({ release: "2024-02" })],
         }),
       ];
@@ -883,6 +885,8 @@ describe("buildData", () => {
         "language",
         "runtime",
       ]);
+      expect(buildData.getUniqueProducts([])).toEqual([]);
+      expect(buildData.getUniqueProducts(items)).toEqual(["v2", "v3"]);
     });
 
     it("assigns flags based on latest release membership", () => {

--- a/packages/techradar/scripts/buildData.ts
+++ b/packages/techradar/scripts/buildData.ts
@@ -254,6 +254,7 @@ export async function parseDirectory(
           existing.ring = item.ring || existing.ring;
           existing.segment = item.segment || existing.segment;
           existing.tags = item.tags;
+          existing.products = item.products;
           existing.teams = item.teams;
           existing.links = item.links;
           existing.featured = item.featured;
@@ -300,6 +301,7 @@ export async function parseDirectory(
           featured: frontmatter.featured,
           flag: Flag.Default,
           tags: frontmatter.tags,
+          products: frontmatter.products,
           revisions: [
             {
               release: releaseDate,
@@ -322,6 +324,7 @@ export async function parseDirectory(
         existing.ring = frontmatter.ring;
         existing.segment = frontmatter.segment;
         existing.tags = frontmatter.tags;
+        existing.products = frontmatter.products;
         existing.teams = teams;
         existing.links = frontmatter.links;
         existing.featured = frontmatter.featured;
@@ -384,6 +387,16 @@ export function getUniqueTags(items: Item[]): string[] {
   return Array.from(tags).sort();
 }
 
+export function getUniqueProducts(items: Item[]): string[] {
+  const products = new Set<string>();
+  for (const item of items) {
+    for (const product of item.products ?? []) {
+      products.add(product);
+    }
+  }
+  return Array.from(products).sort();
+}
+
 export function getFlag(item: Item, allReleases: string[]): Flag {
   if (allReleases.length === 1) return Flag.Default;
 
@@ -401,6 +414,7 @@ export function getFlag(item: Item, allReleases: string[]): Flag {
 export function postProcessItems(items: Item[]): {
   releases: string[];
   tags: string[];
+  products: string[];
   items: Item[];
 } {
   const filteredItems =
@@ -412,6 +426,7 @@ export function postProcessItems(items: Item[]): {
 
   const releases = getUniqueReleases(filteredItems);
   const uniqueTags = getUniqueTags(filteredItems);
+  const uniqueProducts = getUniqueProducts(filteredItems);
 
   for (const item of filteredItems) {
     computeRevisionDiffs(item.revisions);
@@ -454,13 +469,19 @@ export function postProcessItems(items: Item[]): {
 
     if (!processedItem.revisions?.length) delete processedItem.revisions;
     if (!processedItem.tags?.length) delete processedItem.tags;
+    if (!processedItem.products?.length) delete processedItem.products;
     if (!processedItem.teams?.length) delete processedItem.teams;
     if (!processedItem.links?.length) delete processedItem.links;
 
     return processedItem;
   });
 
-  return { releases, tags: uniqueTags, items: processedItems };
+  return {
+    releases,
+    tags: uniqueTags,
+    products: uniqueProducts,
+    items: processedItems,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/techradar/scripts/validateFrontmatter.ts
+++ b/packages/techradar/scripts/validateFrontmatter.ts
@@ -29,6 +29,7 @@ export const FrontmatterSchema = z.object({
   segment: z.enum(segmentIds),
   featured: z.boolean().default(true),
   tags: z.array(z.string()).default([]),
+  products: z.array(z.string()).default([]),
   teams: z.array(z.string()).default([]),
   links: z.array(LinkSchema).default([]),
 });

--- a/packages/techradar/src/__tests__/pages/segment/segment.test.tsx
+++ b/packages/techradar/src/__tests__/pages/segment/segment.test.tsx
@@ -7,6 +7,8 @@ const mockState = vi.hoisted(() => ({
   highlight: {
     highlightedIds: [],
     filterActive: false,
+    filterMatchIds: new Set<string>(),
+    hasFilter: false,
     activeFlags: new Set<string>(),
     activeTags: new Set<string>(),
     activeTeams: new Set<string>(),
@@ -21,6 +23,7 @@ const mockState = vi.hoisted(() => ({
   getItems: vi.fn(),
   getSegment: vi.fn(),
   getSegments: vi.fn(),
+  getToggle: vi.fn(),
   getRing: vi.fn(),
   getRings: vi.fn(),
   groupItemsByRing: vi.fn(),
@@ -67,6 +70,10 @@ vi.mock("@/components/SegmentRadar/SegmentRadar", () => ({
     mockState.segmentRadarProps(props);
     return <div data-testid="segment-radar" />;
   },
+}));
+
+vi.mock("@/components/RadarFilters/RadarFilters", () => ({
+  RadarFilters: () => <div data-testid="radar-filters" />,
 }));
 
 vi.mock("@/components/SeoHead/SeoHead", () => ({
@@ -118,6 +125,7 @@ vi.mock("@/lib/data", () => ({
   getItems: mockState.getItems,
   getSegment: mockState.getSegment,
   getSegments: mockState.getSegments,
+  getToggle: mockState.getToggle,
   getRing: mockState.getRing,
   getRings: mockState.getRings,
   groupItemsByRing: mockState.groupItemsByRing,
@@ -220,8 +228,11 @@ describe("Segment detail page", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockState.highlight.filterMatchIds = new Set<string>();
+    mockState.highlight.hasFilter = false;
     mockState.getAppName.mockReturnValue("Test Radar");
     mockState.getChartConfig.mockReturnValue({ size: 1200, blipSize: 12 });
+    mockState.getToggle.mockReturnValue(true);
     mockState.getSegment.mockImplementation((id: string) =>
       segments.find((entry) => entry.id === id),
     );
@@ -280,11 +291,61 @@ describe("Segment detail page", () => {
     );
   });
 
+  it("renders radar filters on the segment page", () => {
+    render(<SegmentPage segmentId={segment.id} />);
+
+    expect(screen.getByTestId("radar-filters")).toBeInTheDocument();
+  });
+
   it("renders ring sections with items grouped by ring", () => {
     render(<SegmentPage segmentId={segment.id} />);
 
     expect(screen.getByRole("heading", { name: "Adopt" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Trial" })).toBeInTheDocument();
+    expect(screen.getByText("React")).toBeInTheDocument();
+    expect(screen.getByText("Deno")).toBeInTheDocument();
+    expect(screen.getByText("Ember")).toBeInTheDocument();
+  });
+
+  it("groups only filter-matched items when filters are active", () => {
+    mockState.highlight.filterMatchIds = new Set(["deno"]);
+    mockState.highlight.hasFilter = true;
+    mockState.groupItemsByRing.mockReturnValue({
+      adopt: [],
+      trial: [items[1]],
+      assess: [],
+    });
+
+    render(<SegmentPage segmentId={segment.id} />);
+
+    expect(mockState.groupItemsByRing).toHaveBeenCalledWith([items[1]]);
+    expect(screen.queryByText("React")).not.toBeInTheDocument();
+    expect(screen.getByText("Deno")).toBeInTheDocument();
+    expect(screen.queryByText("Ember")).not.toBeInTheDocument();
+  });
+
+  it("does not render radar filters when showFilterOnSegmentPage is disabled", () => {
+    mockState.getToggle.mockImplementation(
+      (key: string) => key !== "showFilterOnSegmentPage",
+    );
+
+    render(<SegmentPage segmentId={segment.id} />);
+
+    expect(screen.queryByTestId("radar-filters")).not.toBeInTheDocument();
+  });
+
+  it("does not filter ring groups when showFilterOnSegmentPage is disabled", () => {
+    mockState.getToggle.mockImplementation(
+      (key: string) => key !== "showFilterOnSegmentPage",
+    );
+    mockState.highlight.filterMatchIds = new Set(["deno"]);
+    mockState.highlight.hasFilter = true;
+
+    render(<SegmentPage segmentId={segment.id} />);
+
+    expect(mockState.groupItemsByRing).toHaveBeenCalledWith(
+      expect.arrayContaining(items),
+    );
     expect(screen.getByText("React")).toBeInTheDocument();
     expect(screen.getByText("Deno")).toBeInTheDocument();
     expect(screen.getByText("Ember")).toBeInTheDocument();

--- a/packages/techradar/src/components/Chip/Chip.module.scss
+++ b/packages/techradar/src/components/Chip/Chip.module.scss
@@ -46,6 +46,11 @@ $rtk-chip-compact-min-height: 22px;
     color: var(--rtk-chip-tag-fg);
   }
 
+  &[data-chip-kind="product"] {
+    background-color: color-mix(in srgb, var(--rtk-chip-product-bg) 85%, transparent);
+    color: var(--rtk-chip-product-fg);
+  }
+
   &[data-chip-kind="team"] {
     background-color: color-mix(in srgb, var(--rtk-chip-team-bg) 85%, transparent);
     color: var(--rtk-chip-team-fg);

--- a/packages/techradar/src/components/ItemDetail/ItemDetail.module.scss
+++ b/packages/techradar/src/components/ItemDetail/ItemDetail.module.scss
@@ -119,6 +119,17 @@
   margin: 0;
 }
 
+.productsContainer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $pds-spacing-static-x-small;
+  margin-top: $pds-spacing-static-small;
+}
+
+.productsContainer :global(a) {
+  margin: 0;
+}
+
 .teamsContainer {
   display: flex;
   flex-wrap: wrap;

--- a/packages/techradar/src/components/ItemDetail/ItemDetail.tsx
+++ b/packages/techradar/src/components/ItemDetail/ItemDetail.tsx
@@ -133,14 +133,18 @@ export function ItemDetail({ item, segmentTitle }: ItemProps) {
               {item.tags?.map((tag) => (
                 <Tag key={tag} tag={tag} href={tagHref(tag)} />
               ))}
-              {item.products?.map((product) => (
-                <Product
-                  key={product}
-                  product={product}
-                  href={productHref(product)}
-                />
-              ))}
             </div>
+            {!!item.products && item.products.length > 0 && (
+              <div className={styles.productsContainer}>
+                {item.products.map((product) => (
+                  <Product
+                    key={product}
+                    product={product}
+                    href={productHref(product)}
+                  />
+                ))}
+              </div>
+            )}
             {!!item.teams && item.teams.length > 0 && (
               <div className={styles.teamsContainer}>
                 <Teams teams={item.teams} getTeamHref={getTeamHref} />

--- a/packages/techradar/src/components/ItemDetail/ItemDetail.tsx
+++ b/packages/techradar/src/components/ItemDetail/ItemDetail.tsx
@@ -10,6 +10,7 @@ import { type CSSProperties, type ReactNode, useState } from "react";
 
 import { RingBadge } from "@/components/Badge/Badge";
 import { DescriptionEdit, RingChange, RingInitial } from "@/components/Icons";
+import { Product } from "@/components/Products/Products";
 import { SafeHtml } from "@/components/SafeHtml/SafeHtml";
 import { Tag } from "@/components/Tags/Tags";
 import { Team, Teams } from "@/components/Teams/Teams";
@@ -43,9 +44,14 @@ export function ItemDetail({ item, segmentTitle }: ItemProps) {
     .includes(item.release);
 
   const tagFilterEnabled = getToggle("showTagFilter");
+  const productFilterEnabled = getToggle("showProductFilter");
   const teamFilterEnabled = getToggle("showTeamFilter");
   const tagHref = (tag: string) =>
     tagFilterEnabled ? `/?tags=${encodeURIComponent(tag)}` : undefined;
+  const productHref = (product: string) =>
+    productFilterEnabled
+      ? `/?products=${encodeURIComponent(product)}`
+      : undefined;
   const getTeamHref = (team: string) =>
     teamFilterEnabled ? `/?teams=${encodeURIComponent(team)}` : undefined;
 
@@ -126,6 +132,13 @@ export function ItemDetail({ item, segmentTitle }: ItemProps) {
             <div className={styles.tags}>
               {item.tags?.map((tag) => (
                 <Tag key={tag} tag={tag} href={tagHref(tag)} />
+              ))}
+              {item.products?.map((product) => (
+                <Product
+                  key={product}
+                  product={product}
+                  href={productHref(product)}
+                />
               ))}
             </div>
             {!!item.teams && item.teams.length > 0 && (

--- a/packages/techradar/src/components/ItemDetail/__tests__/ItemDetail.test.tsx
+++ b/packages/techradar/src/components/ItemDetail/__tests__/ItemDetail.test.tsx
@@ -227,6 +227,18 @@ describe("ItemDetail", () => {
     );
   });
 
+  it("renders products in a dedicated row below tags", () => {
+    renderItemDetail({ tags: ["frontend"], products: ["v2"] });
+
+    const tagsContainer = screen.getByText("frontend").closest("div");
+    const productsContainer = screen.getByText("v2").closest("div");
+
+    expect(tagsContainer).toHaveClass("tags");
+    expect(productsContainer).toHaveClass("productsContainer");
+    expect(productsContainer).not.toBe(tagsContainer);
+    expect(tagsContainer?.nextElementSibling).toBe(productsContainer);
+  });
+
   it("shows the not maintained notification when the release is older than the last three releases", () => {
     renderItemDetail({ release: "2024-01-15" });
 

--- a/packages/techradar/src/components/ItemDetail/__tests__/ItemDetail.test.tsx
+++ b/packages/techradar/src/components/ItemDetail/__tests__/ItemDetail.test.tsx
@@ -160,6 +160,7 @@ function createItem(overrides: Partial<Item> = {}): Item {
     segment: "languages-and-frameworks",
     flag: Flag.Default,
     tags: ["frontend", "typescript"],
+    products: ["v2"],
     release: "2025-07-01",
     revisions: [],
     position: [0.1, 0.2],
@@ -198,12 +199,13 @@ describe("ItemDetail", () => {
     mockState.getRings.mockReturnValue(Object.values(rings));
     mockState.getToggle.mockImplementation((key: string) => {
       if (key === "showTagFilter") return true;
+      if (key === "showProductFilter") return true;
       if (key === "showTeamFilter") return true;
       return false;
     });
   });
 
-  it("renders the item title, ring, segment link, tags, teams, body, and edit link", () => {
+  it("renders the item title, ring, segment link, tags, products, teams, body, and edit link", () => {
     renderItemDetail();
 
     expect(screen.getByText("React")).toBeInTheDocument();
@@ -213,6 +215,7 @@ describe("ItemDetail", () => {
     ).toHaveAttribute("href", "/languages-and-frameworks");
     expect(screen.getByText("frontend")).toBeInTheDocument();
     expect(screen.getByText("typescript")).toBeInTheDocument();
+    expect(screen.getByText("v2")).toBeInTheDocument();
     expect(screen.getByText("Team Alpha")).toBeInTheDocument();
     expect(screen.getByText("Team Beta")).toBeInTheDocument();
     expect(
@@ -468,7 +471,7 @@ describe("ItemDetail", () => {
     });
   });
 
-  describe("tag and team filter links", () => {
+  describe("tag, product, and team filter links", () => {
     it("renders tag badges as links to the home page with the tag filter when showTagFilter is enabled", () => {
       renderItemDetail({ tags: ["frontend"] });
 
@@ -481,6 +484,13 @@ describe("ItemDetail", () => {
 
       const teamLink = screen.getByRole("link", { name: /team alpha/i });
       expect(teamLink).toHaveAttribute("href", "/?teams=Team%20Alpha");
+    });
+
+    it("renders product badges as links to the home page with the product filter when showProductFilter is enabled", () => {
+      renderItemDetail({ products: ["v2"] });
+
+      const productLink = screen.getByRole("link", { name: /v2/i });
+      expect(productLink).toHaveAttribute("href", "/?products=v2");
     });
 
     it("renders tag badges as plain (non-link) when showTagFilter is disabled", () => {
@@ -498,7 +508,7 @@ describe("ItemDetail", () => {
 
     it("renders team badges as plain (non-link) when showTeamFilter is disabled", () => {
       mockState.getToggle.mockImplementation(
-        (key: string) => key === "showTagFilter",
+        (key: string) => key === "showTagFilter" || key === "showProductFilter",
       );
 
       renderItemDetail({ tags: [], teams: ["Team Alpha"] });
@@ -507,6 +517,19 @@ describe("ItemDetail", () => {
         screen.queryByRole("link", { name: /team alpha/i }),
       ).not.toBeInTheDocument();
       expect(screen.getByText("Team Alpha")).toBeInTheDocument();
+    });
+
+    it("renders product badges as plain (non-link) when showProductFilter is disabled", () => {
+      mockState.getToggle.mockImplementation(
+        (key: string) => key === "showTagFilter" || key === "showTeamFilter",
+      );
+
+      renderItemDetail({ products: ["v2"] });
+
+      expect(
+        screen.queryByRole("link", { name: /v2/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("v2")).toBeInTheDocument();
     });
   });
 });

--- a/packages/techradar/src/components/Products/Products.module.scss
+++ b/packages/techradar/src/components/Products/Products.module.scss
@@ -4,4 +4,12 @@
 
 .productLink {
   text-decoration: none;
+  color: inherit;
+  opacity: 0.7;
+  transition: opacity 150ms ease-in-out;
+
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
+  }
 }

--- a/packages/techradar/src/components/Products/Products.module.scss
+++ b/packages/techradar/src/components/Products/Products.module.scss
@@ -1,0 +1,7 @@
+.product {
+  display: inline-flex;
+}
+
+.productLink {
+  text-decoration: none;
+}

--- a/packages/techradar/src/components/Products/Products.tsx
+++ b/packages/techradar/src/components/Products/Products.tsx
@@ -1,0 +1,34 @@
+import { PIcon } from "@porsche-design-system/components-react/ssr";
+import Link from "next/link";
+
+import { Chip } from "@/components/Chip/Chip";
+import { cn } from "@/lib/utils";
+import styles from "./Products.module.scss";
+
+type ProductProps = {
+  product: string;
+  compact?: boolean;
+  href?: string;
+};
+
+export function Product({ product, compact, href }: ProductProps) {
+  const badge = (
+    <Chip
+      kind="product"
+      compact={compact}
+      iconSlot={<PIcon name="stack" size="x-small" aria-hidden="true" />}
+    >
+      {product}
+    </Chip>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={cn(styles.product, styles.productLink)}>
+        {badge}
+      </Link>
+    );
+  }
+
+  return <span className={cn(styles.product)}>{badge}</span>;
+}

--- a/packages/techradar/src/components/Products/__tests__/Products.test.tsx
+++ b/packages/techradar/src/components/Products/__tests__/Products.test.tsx
@@ -62,6 +62,7 @@ describe("Product", () => {
 
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("href", "/?products=v2");
+    expect(link).toHaveClass("productLink");
     expect(link).toContainElement(screen.getByTestId("chip"));
   });
 });

--- a/packages/techradar/src/components/Products/__tests__/Products.test.tsx
+++ b/packages/techradar/src/components/Products/__tests__/Products.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { Product } from "../Products";
+
+interface MockChipProps {
+  kind?: string;
+  children?: ReactNode;
+  iconSlot?: ReactNode;
+  compact?: boolean;
+}
+
+vi.mock("@/components/Chip/Chip", () => ({
+  Chip: ({ kind, children, iconSlot, compact }: MockChipProps) => (
+    <span
+      data-testid="chip"
+      data-kind={kind}
+      data-compact={compact ? "true" : "false"}
+    >
+      {iconSlot}
+      {children}
+    </span>
+  ),
+}));
+
+vi.mock("@porsche-design-system/components-react/ssr", () => ({
+  PIcon: ({ name }: { name?: string }) => (
+    <span data-testid="p-icon" data-name={name} />
+  ),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...rest }: ComponentProps<"a">) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("Product", () => {
+  it("renders a themed product chip with the stack icon", () => {
+    render(<Product product="v2" />);
+
+    expect(screen.getByTestId("chip")).toHaveTextContent("v2");
+    expect(screen.getByTestId("chip")).toHaveAttribute("data-kind", "product");
+    expect(screen.getByTestId("p-icon")).toHaveAttribute("data-name", "stack");
+  });
+
+  it("passes the compact prop", () => {
+    render(<Product product="v2" compact />);
+
+    expect(screen.getByTestId("chip")).toHaveAttribute("data-compact", "true");
+  });
+
+  it("renders as a plain span when no href is provided", () => {
+    render(<Product product="v2" />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders as a link when an href is provided", () => {
+    render(<Product product="v2" href="/?products=v2" />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/?products=v2");
+    expect(link).toContainElement(screen.getByTestId("chip"));
+  });
+});

--- a/packages/techradar/src/components/Radar/Chart.tsx
+++ b/packages/techradar/src/components/Radar/Chart.tsx
@@ -36,6 +36,9 @@ export interface ChartProps {
 
 interface WedgeProps {
   segmentId: string;
+  href:
+    | string
+    | { pathname: string; query?: Record<string, string>; hash?: string };
   segmentColor: string;
   ringId: string;
   d: string;
@@ -47,6 +50,7 @@ interface WedgeProps {
 
 const Wedge: FC<WedgeProps> = ({
   segmentId,
+  href,
   segmentColor,
   ringId,
   d,
@@ -81,7 +85,7 @@ const Wedge: FC<WedgeProps> = ({
   };
   return (
     <Link
-      href={`/${segmentId}#ring-${ringId}`}
+      href={href}
       aria-label={ariaLabel}
       className={styles.wedge}
       onMouseEnter={enter}
@@ -109,8 +113,20 @@ const ChartInner: FC<ChartProps> = ({
   className,
   onWedgeCommit,
 }) => {
-  const { highlightedIds, filterMatchIds, filterActive, setHighlightPreview } =
-    useRadarHighlight();
+  const {
+    highlightedIds,
+    filterMatchIds,
+    filterActive,
+    activeFlags,
+    activeTags,
+    activeProducts,
+    activeTeams,
+    setHighlightPreview,
+  } = useRadarHighlight();
+  const resolvedActiveFlags = activeFlags ?? new Set<string>();
+  const resolvedActiveTags = activeTags ?? new Set<string>();
+  const resolvedActiveProducts = activeProducts ?? new Set<string>();
+  const resolvedActiveTeams = activeTeams ?? new Set<string>();
   const { theme } = useTheme();
   const segmentColor = (seg: Segment) => theme.radar.segments[seg.position - 1];
   const liveHighlightSet = useMemo(
@@ -150,6 +166,7 @@ const ChartInner: FC<ChartProps> = ({
   const centerX = viewBoxCenter;
   const centerY = viewBoxCenter;
   const showBlipChange = getToggle("showBlipChange");
+  const showFilterOnSegmentPage = getToggle("showFilterOnSegmentPage");
 
   const numSegments = segments.length;
   const sweep = numSegments > 0 ? 360 / numSegments : 90;
@@ -164,6 +181,53 @@ const ChartInner: FC<ChartProps> = ({
     }
     return map;
   }, [items]);
+
+  const activeFilterQuery = useMemo(() => {
+    const query: Record<string, string> = {};
+
+    if (resolvedActiveFlags.size > 0) {
+      query.flags = [...resolvedActiveFlags].join(",");
+    }
+    if (resolvedActiveTags.size > 0) {
+      query.tags = [...resolvedActiveTags].join(",");
+    }
+    if (resolvedActiveProducts.size > 0) {
+      query.products = [...resolvedActiveProducts].join(",");
+    }
+    if (resolvedActiveTeams.size > 0) {
+      query.teams = [...resolvedActiveTeams].join(",");
+    }
+
+    return query;
+  }, [
+    resolvedActiveFlags,
+    resolvedActiveTags,
+    resolvedActiveProducts,
+    resolvedActiveTeams,
+  ]);
+
+  const buildSegmentHref = useCallback(
+    (
+      segmentId: string,
+      hash?: string,
+    ):
+      | string
+      | { pathname: string; query?: Record<string, string>; hash?: string } => {
+      if (
+        !showFilterOnSegmentPage ||
+        Object.keys(activeFilterQuery).length === 0
+      ) {
+        return hash ? `/${segmentId}#${hash}` : `/${segmentId}`;
+      }
+
+      return {
+        pathname: `/${segmentId}`,
+        query: activeFilterQuery,
+        hash,
+      };
+    },
+    [activeFilterQuery, showFilterOnSegmentPage],
+  );
 
   const getStartAngle = (position: number): number =>
     computeSegmentStartAngle(position, numSegments);
@@ -348,7 +412,10 @@ const ChartInner: FC<ChartProps> = ({
           <defs>
             <path id={pathId} d={d} fill="none" />
           </defs>
-          <Link href={`/${segment.id}`} className={styles.segmentLabel}>
+          <Link
+            href={buildSegmentHref(segment.id)}
+            className={styles.segmentLabel}
+          >
             <text>
               <textPath
                 href={`#${pathId}`}
@@ -390,6 +457,7 @@ const ChartInner: FC<ChartProps> = ({
           <Wedge
             key={`wedge-${segment.id}-${ring.id}`}
             segmentId={segment.id}
+            href={buildSegmentHref(segment.id, `ring-${ring.id}`)}
             segmentColor={segmentColor(segment)}
             ringId={ring.id}
             d={d}

--- a/packages/techradar/src/components/Radar/__tests__/Chart.wedges.test.tsx
+++ b/packages/techradar/src/components/Radar/__tests__/Chart.wedges.test.tsx
@@ -1,10 +1,32 @@
 import { fireEvent, render } from "@testing-library/react";
 
 import { Chart } from "@/components/Radar/Chart";
+import { getToggle } from "@/lib/data";
 import { useRadarHighlight } from "@/lib/RadarHighlightContext";
 import { Flag, type Item, type Ring, type Segment } from "@/lib/types";
 
 const setHighlightPreview = vi.fn();
+
+function createDefaultHighlightState() {
+  return {
+    highlightedIds: [],
+    filterMatchIds: new Set<string>(),
+    filterActive: false,
+    hasFilter: false,
+    suppressTooltips: false,
+    activeFlags: new Set<string>(),
+    activeTags: new Set<string>(),
+    activeProducts: new Set<string>(),
+    activeTeams: new Set<string>(),
+    setHighlight: vi.fn(),
+    setHighlightPreview,
+    toggleFlag: vi.fn(),
+    toggleTag: vi.fn(),
+    toggleProduct: vi.fn(),
+    toggleTeam: vi.fn(),
+    clearFilters: vi.fn(),
+  };
+}
 
 vi.mock("@/lib/data", () => ({
   getToggle: vi.fn(() => false),
@@ -40,12 +62,7 @@ vi.mock("@/lib/ThemeContext", () => ({
 }));
 
 vi.mock("@/lib/RadarHighlightContext", () => ({
-  useRadarHighlight: vi.fn(() => ({
-    highlightedIds: [],
-    filterMatchIds: new Set<string>(),
-    filterActive: false,
-    setHighlightPreview,
-  })),
+  useRadarHighlight: vi.fn(() => createDefaultHighlightState()),
 }));
 
 const segments: Segment[] = [
@@ -148,6 +165,11 @@ const items: Item[] = [
 describe("Chart wedges", () => {
   beforeEach(() => {
     setHighlightPreview.mockClear();
+    vi.mocked(useRadarHighlight).mockReset();
+    vi.mocked(useRadarHighlight).mockReturnValue(createDefaultHighlightState());
+    vi.mocked(getToggle).mockImplementation(
+      (key: string) => key === "showFilterOnSegmentPage",
+    );
   });
 
   it("renders one wedge per (segment, ring) pair", () => {
@@ -166,20 +188,131 @@ describe("Chart wedges", () => {
     expect(wedge).not.toBeNull();
   });
 
-  it("wedge aria-label includes segment title, ring title, and item count", () => {
+  it("preserves active filter query params in wedge hrefs", () => {
+    const mockUseRadarHighlight = vi.mocked(useRadarHighlight);
+    mockUseRadarHighlight.mockReturnValue({
+      highlightedIds: ["react", "vue"],
+      filterMatchIds: new Set(["react", "vue"]),
+      filterActive: true,
+      hasFilter: true,
+      suppressTooltips: false,
+      activeFlags: new Set(["new"]),
+      activeTags: new Set(["frontend"]),
+      activeProducts: new Set(["v2"]),
+      activeTeams: new Set(["platform"]),
+      setHighlight: vi.fn(),
+      setHighlightPreview,
+      toggleFlag: vi.fn(),
+      toggleTag: vi.fn(),
+      toggleProduct: vi.fn(),
+      toggleTeam: vi.fn(),
+      clearFilters: vi.fn(),
+    });
+
+    const { container } = render(
+      <Chart size={800} segments={segments} rings={rings} items={items} />,
+    );
+    const wedge = container.querySelector(
+      'a[href*="/tools?"][href*="#ring-adopt"]',
+    );
+    expect(wedge).not.toBeNull();
+    expect(wedge?.getAttribute("href")).toContain("flags=new");
+    expect(wedge?.getAttribute("href")).toContain("tags=frontend");
+    expect(wedge?.getAttribute("href")).toContain("products=v2");
+    expect(wedge?.getAttribute("href")).toContain("teams=platform");
+  });
+
+  it("preserves active filter query params in segment label hrefs", () => {
+    const mockUseRadarHighlight = vi.mocked(useRadarHighlight);
+    mockUseRadarHighlight.mockReturnValue({
+      highlightedIds: ["react"],
+      filterMatchIds: new Set(["react"]),
+      filterActive: true,
+      hasFilter: true,
+      suppressTooltips: false,
+      activeFlags: new Set<string>(),
+      activeTags: new Set(["frontend"]),
+      activeProducts: new Set<string>(),
+      activeTeams: new Set<string>(),
+      setHighlight: vi.fn(),
+      setHighlightPreview,
+      toggleFlag: vi.fn(),
+      toggleTag: vi.fn(),
+      toggleProduct: vi.fn(),
+      toggleTeam: vi.fn(),
+      clearFilters: vi.fn(),
+    });
+
+    const { container } = render(
+      <Chart size={800} segments={segments} rings={rings} items={items} />,
+    );
+    const labelLinks = Array.from(
+      container.querySelectorAll('a[href*="/tools?"]'),
+    );
+    const labelLink = labelLinks.find(
+      (link) => !(link.getAttribute("href") ?? "").includes("#ring-"),
+    );
+    expect(labelLink).toBeDefined();
+    expect(labelLink?.getAttribute("href")).toContain("tags=frontend");
+  });
+
+  it("does not preserve active filter query params when segment-page filtering is disabled", () => {
+    vi.mocked(getToggle).mockImplementation(() => false);
+
+    const mockUseRadarHighlight = vi.mocked(useRadarHighlight);
+    mockUseRadarHighlight.mockReturnValue({
+      highlightedIds: ["react", "vue"],
+      filterMatchIds: new Set(["react", "vue"]),
+      filterActive: true,
+      hasFilter: true,
+      suppressTooltips: false,
+      activeFlags: new Set(["new"]),
+      activeTags: new Set(["frontend"]),
+      activeProducts: new Set(["v2"]),
+      activeTeams: new Set(["platform"]),
+      setHighlight: vi.fn(),
+      setHighlightPreview,
+      toggleFlag: vi.fn(),
+      toggleTag: vi.fn(),
+      toggleProduct: vi.fn(),
+      toggleTeam: vi.fn(),
+      clearFilters: vi.fn(),
+    });
+
     const { container } = render(
       <Chart size={800} segments={segments} rings={rings} items={items} />,
     );
     const wedge = container.querySelector('a[href$="/tools#ring-adopt"]');
     expect(wedge).not.toBeNull();
+    expect(wedge?.getAttribute("href")).not.toContain("?");
+
+    const labelLink = Array.from(
+      container.querySelectorAll('a[href="/tools"]'),
+    ).find((link) => !(link.getAttribute("href") ?? "").includes("#ring-"));
+    expect(labelLink).toBeDefined();
+    expect(labelLink?.getAttribute("href")).toBe("/tools");
+  });
+
+  it("wedge aria-label includes segment title, ring title, and item count", () => {
+    const { container } = render(
+      <Chart size={800} segments={segments} rings={rings} items={items} />,
+    );
+    const wedge = container.querySelector(
+      'a[href*="/tools"][href*="#ring-adopt"]',
+    );
+    expect(wedge).not.toBeNull();
     expect(wedge?.getAttribute("aria-label")).toBe("Tools, Adopt (2 items)");
 
-    const empty = container.querySelector('a[href$="/platforms#ring-adopt"]');
+    const empty = container.querySelector(
+      'a[href*="/platforms"][href*="#ring-adopt"]',
+    );
     expect(empty?.getAttribute("aria-label")).toBe(
       "Platforms, Adopt (0 items)",
     );
 
-    const single = container.querySelector('a[href$="/languages#ring-trial"]');
+    const single = container.querySelector(
+      'a[href*="/languages"][href*="#ring-trial"]',
+    );
     expect(single?.getAttribute("aria-label")).toBe(
       "Languages, Trial (1 item)",
     );
@@ -189,7 +322,9 @@ describe("Chart wedges", () => {
     const { container } = render(
       <Chart size={800} segments={segments} rings={rings} items={items} />,
     );
-    const wedge = container.querySelector('a[href$="/tools#ring-adopt"]');
+    const wedge = container.querySelector(
+      'a[href*="/tools"][href*="#ring-adopt"]',
+    );
     expect(wedge).not.toBeNull();
     if (!wedge) return;
 
@@ -204,7 +339,9 @@ describe("Chart wedges", () => {
     const { container } = render(
       <Chart size={800} segments={segments} rings={rings} items={items} />,
     );
-    const wedge = container.querySelector('a[href$="/tools#ring-adopt"]');
+    const wedge = container.querySelector(
+      'a[href*="/tools"][href*="#ring-adopt"]',
+    );
     expect(wedge).not.toBeNull();
     if (!wedge) return;
 
@@ -216,7 +353,9 @@ describe("Chart wedges", () => {
     const { container } = render(
       <Chart size={800} segments={segments} rings={rings} items={items} />,
     );
-    const wedge = container.querySelector('a[href$="/tools#ring-adopt"]');
+    const wedge = container.querySelector(
+      'a[href*="/tools"][href*="#ring-adopt"]',
+    );
     expect(wedge).not.toBeNull();
     if (!wedge) return;
 
@@ -233,7 +372,9 @@ describe("Chart wedges", () => {
     const { container } = render(
       <Chart size={800} segments={segments} rings={rings} items={items} />,
     );
-    const wedge = container.querySelector('a[href$="/tools#ring-adopt"]');
+    const wedge = container.querySelector(
+      'a[href*="/tools"][href*="#ring-adopt"]',
+    );
     const path = wedge?.querySelector("path");
     expect(path).not.toBeNull();
     expect(path?.getAttribute("d")?.length ?? 0).toBeGreaterThan(0);
@@ -259,11 +400,13 @@ describe("Chart wedges", () => {
       suppressTooltips: false,
       activeFlags: new Set(),
       activeTags: new Set(),
+      activeProducts: new Set(),
       activeTeams: new Set(),
       setHighlight: vi.fn(),
       setHighlightPreview,
       toggleFlag: vi.fn(),
       toggleTag: vi.fn(),
+      toggleProduct: vi.fn(),
       toggleTeam: vi.fn(),
       clearFilters: vi.fn(),
     });
@@ -271,7 +414,9 @@ describe("Chart wedges", () => {
     const { container, rerender } = render(
       <Chart size={800} segments={segments} rings={rings} items={items} />,
     );
-    const wedge = container.querySelector('a[href$="/tools#ring-adopt"]');
+    const wedge = container.querySelector(
+      'a[href*="/tools"][href*="#ring-adopt"]',
+    );
     expect(wedge).not.toBeNull();
     if (!wedge) return;
 
@@ -289,11 +434,13 @@ describe("Chart wedges", () => {
       suppressTooltips: false,
       activeFlags: new Set(),
       activeTags: new Set(),
+      activeProducts: new Set(),
       activeTeams: new Set(),
       setHighlight: vi.fn(),
       setHighlightPreview,
       toggleFlag: vi.fn(),
       toggleTag: vi.fn(),
+      toggleProduct: vi.fn(),
       toggleTeam: vi.fn(),
       clearFilters: vi.fn(),
     });
@@ -323,11 +470,13 @@ describe("Chart wedges", () => {
       suppressTooltips: false,
       activeFlags: new Set(),
       activeTags: new Set(),
+      activeProducts: new Set(),
       activeTeams: new Set(),
       setHighlight: vi.fn(),
       setHighlightPreview,
       toggleFlag: vi.fn(),
       toggleTag: vi.fn(),
+      toggleProduct: vi.fn(),
       toggleTeam: vi.fn(),
       clearFilters: vi.fn(),
     });

--- a/packages/techradar/src/components/RadarFilters/RadarFilters.tsx
+++ b/packages/techradar/src/components/RadarFilters/RadarFilters.tsx
@@ -2,7 +2,13 @@ import { PIcon, PTag } from "@porsche-design-system/components-react/ssr";
 import type { CSSProperties } from "react";
 import { Chip } from "@/components/Chip/Chip";
 import { blipSvgMap } from "@/lib/blipIcons";
-import { getFlags, getTags, getTeams, getToggle } from "@/lib/data";
+import {
+  getFlags,
+  getProducts,
+  getTags,
+  getTeams,
+  getToggle,
+} from "@/lib/data";
 import { useRadarHighlight } from "@/lib/RadarHighlightContext";
 import { cn } from "@/lib/utils";
 import styles from "./RadarFilters.module.scss";
@@ -11,19 +17,23 @@ export function RadarFilters() {
   const {
     activeFlags,
     activeTags,
+    activeProducts,
     activeTeams,
     hasFilter,
     toggleFlag,
     toggleTag,
+    toggleProduct,
     toggleTeam,
     clearFilters,
   } = useRadarHighlight();
 
   const flags = getFlags();
   const tags = getTags();
+  const products = getProducts();
   const teams = getTeams();
 
   const showTags = getToggle("showTagFilter") && tags.length > 0;
+  const showProducts = getToggle("showProductFilter") && products.length > 0;
   const showTeams = getToggle("showTeamFilter") && teams.length > 0;
   const isMultiSelect = getToggle("multiSelectFilters");
 
@@ -106,6 +116,41 @@ export function RadarFilters() {
                     }
                   >
                     {tag}
+                  </Chip>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {showProducts && (
+        <div className={styles.row}>
+          <span className={styles.rowLabel}>
+            <PIcon name="filter" size="x-small" aria-hidden="true" />
+            Product
+          </span>
+          <div className={styles.pills}>
+            {products.map((product) => {
+              const isActive = activeProducts.has(product);
+              return (
+                <button
+                  key={product}
+                  type="button"
+                  onClick={() => toggleProduct(product)}
+                  className={cn(styles.pill, isActive && styles.active)}
+                >
+                  <Chip
+                    kind="product"
+                    iconSlot={
+                      <PIcon
+                        name={isActive ? "close" : "stack"}
+                        size="x-small"
+                        aria-hidden="true"
+                      />
+                    }
+                  >
+                    {product}
                   </Chip>
                 </button>
               );

--- a/packages/techradar/src/components/RadarFilters/RadarFilters.tsx
+++ b/packages/techradar/src/components/RadarFilters/RadarFilters.tsx
@@ -128,7 +128,7 @@ export function RadarFilters() {
         <div className={styles.row}>
           <span className={styles.rowLabel}>
             <PIcon name="filter" size="x-small" aria-hidden="true" />
-            Product
+            Products
           </span>
           <div className={styles.pills}>
             {products.map((product) => {

--- a/packages/techradar/src/components/RadarFilters/__tests__/RadarFilters.test.tsx
+++ b/packages/techradar/src/components/RadarFilters/__tests__/RadarFilters.test.tsx
@@ -1,12 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 
-import { getFlags, getTags, getTeams, getToggle } from "@/lib/data";
+import {
+  getFlags,
+  getProducts,
+  getTags,
+  getTeams,
+  getToggle,
+} from "@/lib/data";
 import { useRadarHighlight } from "@/lib/RadarHighlightContext";
 import { RadarFilters } from "../RadarFilters";
 
 vi.mock("@/lib/data", () => ({
   getFlags: vi.fn(),
+  getProducts: vi.fn(),
   getTags: vi.fn(),
   getTeams: vi.fn(),
   getToggle: vi.fn(),
@@ -48,6 +55,7 @@ vi.mock("@porsche-design-system/components-react/ssr", () => ({
 }));
 
 const mockGetFlags = getFlags as ReturnType<typeof vi.fn>;
+const mockGetProducts = getProducts as ReturnType<typeof vi.fn>;
 const mockGetTags = getTags as ReturnType<typeof vi.fn>;
 const mockGetTeams = getTeams as ReturnType<typeof vi.fn>;
 const mockGetToggle = getToggle as ReturnType<typeof vi.fn>;
@@ -59,17 +67,20 @@ describe("RadarFilters", () => {
       new: { title: "New" },
       changed: { title: "Changed" },
     });
+    mockGetProducts.mockReturnValue(["v2"]);
     mockGetTags.mockReturnValue(["frontend"]);
     mockGetTeams.mockReturnValue(["platform"]);
     mockGetToggle.mockImplementation((key: string) => key !== "showChart");
     mockUseRadarHighlight.mockReturnValue({
       activeFlags: new Set(["new"]),
       activeTags: new Set(["frontend"]),
+      activeProducts: new Set(["v2"]),
       activeTeams: new Set(["platform"]),
       filterActive: true,
       hasFilter: true,
       toggleFlag: vi.fn(),
       toggleTag: vi.fn(),
+      toggleProduct: vi.fn(),
       toggleTeam: vi.fn(),
       clearFilters: vi.fn(),
     });
@@ -95,6 +106,16 @@ describe("RadarFilters", () => {
       .find((el) => el.textContent === "frontend");
     expect(tagChip).toBeDefined();
     expect(tagChip).toHaveAttribute("data-kind", "tag");
+  });
+
+  it("renders the product pill as Chip kind=product", () => {
+    render(<RadarFilters />);
+
+    const productChip = screen
+      .getAllByTestId("chip")
+      .find((el) => el.textContent === "v2");
+    expect(productChip).toBeDefined();
+    expect(productChip).toHaveAttribute("data-kind", "product");
   });
 
   it("renders the team pill as Chip kind=team", () => {
@@ -124,11 +145,13 @@ describe("RadarFilters", () => {
     mockUseRadarHighlight.mockReturnValue({
       activeFlags: new Set<string>(),
       activeTags: new Set<string>(),
+      activeProducts: new Set<string>(),
       activeTeams: new Set<string>(),
       filterActive: true,
       hasFilter: false,
       toggleFlag: vi.fn(),
       toggleTag: vi.fn(),
+      toggleProduct: vi.fn(),
       toggleTeam: vi.fn(),
       clearFilters: vi.fn(),
     });

--- a/packages/techradar/src/components/RadarFilters/__tests__/RadarFilters.test.tsx
+++ b/packages/techradar/src/components/RadarFilters/__tests__/RadarFilters.test.tsx
@@ -111,6 +111,7 @@ describe("RadarFilters", () => {
   it("renders the product pill as Chip kind=product", () => {
     render(<RadarFilters />);
 
+    expect(screen.getByText("Products")).toBeInTheDocument();
     const productChip = screen
       .getAllByTestId("chip")
       .find((el) => el.textContent === "v2");

--- a/packages/techradar/src/lib/RadarHighlightContext.tsx
+++ b/packages/techradar/src/lib/RadarHighlightContext.tsx
@@ -39,6 +39,7 @@ interface HighlightState {
   isPreview: boolean;
   activeFlags: ReadonlySet<string>;
   activeTags: ReadonlySet<string>;
+  activeProducts: ReadonlySet<string>;
   activeTeams: ReadonlySet<string>;
 }
 
@@ -48,6 +49,7 @@ const initialState: HighlightState = {
   isPreview: false,
   activeFlags: emptySet,
   activeTags: emptySet,
+  activeProducts: emptySet,
   activeTeams: emptySet,
 };
 
@@ -56,11 +58,13 @@ type Action =
   | { type: "SET_DIRECT_PREVIEW"; ids: string[] }
   | { type: "TOGGLE_FLAG"; flag: string }
   | { type: "TOGGLE_TAG"; tag: string }
+  | { type: "TOGGLE_PRODUCT"; product: string }
   | { type: "TOGGLE_TEAM"; team: string }
   | {
       type: "SET_FILTERS";
       flags: ReadonlySet<string>;
       tags: ReadonlySet<string>;
+      products: ReadonlySet<string>;
       teams: ReadonlySet<string>;
     }
   | { type: "CLEAR_FILTERS" };
@@ -91,6 +95,11 @@ function reducer(state: HighlightState, action: Action): HighlightState {
         ...state,
         activeTags: toggleValue(state.activeTags, action.tag),
       };
+    case "TOGGLE_PRODUCT":
+      return {
+        ...state,
+        activeProducts: toggleValue(state.activeProducts, action.product),
+      };
     case "TOGGLE_TEAM":
       return {
         ...state,
@@ -101,6 +110,7 @@ function reducer(state: HighlightState, action: Action): HighlightState {
         ...state,
         activeFlags: emptySet,
         activeTags: emptySet,
+        activeProducts: emptySet,
         activeTeams: emptySet,
       };
     case "SET_FILTERS":
@@ -108,6 +118,7 @@ function reducer(state: HighlightState, action: Action): HighlightState {
         ...state,
         activeFlags: action.flags,
         activeTags: action.tags,
+        activeProducts: action.products,
         activeTeams: action.teams,
       };
     default:
@@ -119,11 +130,14 @@ function matchesFilters(
   item: Item,
   flags: ReadonlySet<string>,
   tags: ReadonlySet<string>,
+  products: ReadonlySet<string>,
   teams: ReadonlySet<string>,
 ): boolean {
   // OR within each dimension, AND across dimensions
   if (flags.size > 0 && !flags.has(item.flag)) return false;
   if (tags.size > 0 && !item.tags?.some((t) => tags.has(t))) return false;
+  if (products.size > 0 && !item.products?.some((p) => products.has(p)))
+    return false;
   if (teams.size > 0 && !item.teams?.some((t) => teams.has(t))) return false;
   return true;
 }
@@ -136,11 +150,13 @@ interface RadarHighlightContextValue {
   suppressTooltips: boolean;
   activeFlags: ReadonlySet<string>;
   activeTags: ReadonlySet<string>;
+  activeProducts: ReadonlySet<string>;
   activeTeams: ReadonlySet<string>;
   setHighlight: (ids: string[], active: boolean) => void;
   setHighlightPreview: (ids: string[]) => void;
   toggleFlag: (flag: string) => void;
   toggleTag: (tag: string) => void;
+  toggleProduct: (product: string) => void;
   toggleTeam: (team: string) => void;
   clearFilters: () => void;
 }
@@ -153,11 +169,13 @@ const RadarHighlightContext = createContext<RadarHighlightContextValue>({
   suppressTooltips: false,
   activeFlags: emptySet,
   activeTags: emptySet,
+  activeProducts: emptySet,
   activeTeams: emptySet,
   setHighlight: () => {},
   setHighlightPreview: () => {},
   toggleFlag: () => {},
   toggleTag: () => {},
+  toggleProduct: () => {},
   toggleTeam: () => {},
   clearFilters: () => {},
 });
@@ -179,6 +197,7 @@ function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
 
 const PARAM_FLAGS = "flags";
 const PARAM_TAGS = "tags";
+const PARAM_PRODUCTS = "products";
 const PARAM_TEAMS = "teams";
 
 export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
@@ -198,18 +217,20 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
 
     const flags = parseParam(router.query[PARAM_FLAGS]);
     const tags = parseParam(router.query[PARAM_TAGS]);
+    const products = parseParam(router.query[PARAM_PRODUCTS]);
     const teams = parseParam(router.query[PARAM_TEAMS]);
 
     const s = stateRef.current;
     if (
       setsEqual(flags, s.activeFlags) &&
       setsEqual(tags, s.activeTags) &&
+      setsEqual(products, s.activeProducts) &&
       setsEqual(teams, s.activeTeams)
     ) {
       return;
     }
 
-    dispatch({ type: "SET_FILTERS", flags, tags, teams });
+    dispatch({ type: "SET_FILTERS", flags, tags, products, teams });
   }, [router.isReady, router.query]);
 
   useEffect(() => {
@@ -222,6 +243,7 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
     for (const [param, set] of [
       [PARAM_FLAGS, state.activeFlags],
       [PARAM_TAGS, state.activeTags],
+      [PARAM_PRODUCTS, state.activeProducts],
       [PARAM_TEAMS, state.activeTeams],
     ] as const) {
       const current = query[param];
@@ -245,11 +267,17 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
     }).then(() => {
       isUpdatingUrl.current = false;
     });
-  }, [state.activeFlags, state.activeTags, state.activeTeams]);
+  }, [
+    state.activeFlags,
+    state.activeTags,
+    state.activeProducts,
+    state.activeTeams,
+  ]);
 
   const hasFilter =
     state.activeFlags.size > 0 ||
     state.activeTags.size > 0 ||
+    state.activeProducts.size > 0 ||
     state.activeTeams.size > 0;
 
   const filterMatchIds = useMemo(() => {
@@ -260,6 +288,7 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
           item,
           state.activeFlags,
           state.activeTags,
+          state.activeProducts,
           state.activeTeams,
         ),
       )
@@ -269,6 +298,7 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
     hasFilter,
     state.activeFlags,
     state.activeTags,
+    state.activeProducts,
     state.activeTeams,
   ]);
 
@@ -320,6 +350,10 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
     (tag: string) => dispatch({ type: "TOGGLE_TAG", tag }),
     [],
   );
+  const toggleProduct = useCallback(
+    (product: string) => dispatch({ type: "TOGGLE_PRODUCT", product }),
+    [],
+  );
   const toggleTeam = useCallback(
     (team: string) => dispatch({ type: "TOGGLE_TEAM", team }),
     [],
@@ -338,11 +372,13 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
       suppressTooltips,
       activeFlags: state.activeFlags,
       activeTags: state.activeTags,
+      activeProducts: state.activeProducts,
       activeTeams: state.activeTeams,
       setHighlight,
       setHighlightPreview,
       toggleFlag,
       toggleTag,
+      toggleProduct,
       toggleTeam,
       clearFilters,
     }),
@@ -354,11 +390,13 @@ export const RadarHighlightProvider: FC<{ children: ReactNode }> = ({
       suppressTooltips,
       state.activeFlags,
       state.activeTags,
+      state.activeProducts,
       state.activeTeams,
       setHighlight,
       setHighlightPreview,
       toggleFlag,
       toggleTag,
+      toggleProduct,
       toggleTeam,
       clearFilters,
     ],

--- a/packages/techradar/src/lib/__tests__/RadarHighlightContext.singleSelect.test.tsx
+++ b/packages/techradar/src/lib/__tests__/RadarHighlightContext.singleSelect.test.tsx
@@ -23,24 +23,28 @@ vi.mock("@/lib/data", () => ({
       id: "ts",
       flag: "new",
       tags: ["lang", "frontend"],
+      products: ["v2"],
       teams: ["platform"],
     },
     {
       id: "react",
       flag: "default",
       tags: ["frontend"],
+      products: ["v2"],
       teams: ["frontend"],
     },
     {
       id: "k8s",
       flag: "changed",
       tags: ["infra"],
+      products: ["v3"],
       teams: ["platform"],
     },
     {
       id: "docker",
       flag: "new",
       tags: ["infra"],
+      products: ["v3"],
       teams: ["devops"],
     },
   ]),
@@ -106,6 +110,19 @@ describe("RadarHighlightContext (single-select mode)", () => {
     expect(result.current.activeTags.has("infra")).toBe(true);
     expect(result.current.activeTags.has("frontend")).toBe(false);
     expect(result.current.activeTags.size).toBe(1);
+  });
+
+  it("replaces the active product instead of accumulating", () => {
+    const { result } = renderHook(() => useRadarHighlight(), { wrapper });
+
+    act(() => {
+      result.current.toggleProduct("v2");
+      result.current.toggleProduct("v3");
+    });
+
+    expect(result.current.activeProducts.has("v3")).toBe(true);
+    expect(result.current.activeProducts.has("v2")).toBe(false);
+    expect(result.current.activeProducts.size).toBe(1);
   });
 
   it("replaces the active team instead of accumulating", () => {

--- a/packages/techradar/src/lib/__tests__/RadarHighlightContext.test.tsx
+++ b/packages/techradar/src/lib/__tests__/RadarHighlightContext.test.tsx
@@ -23,24 +23,28 @@ vi.mock("@/lib/data", () => ({
       id: "ts",
       flag: "new",
       tags: ["lang", "frontend"],
+      products: ["v2"],
       teams: ["platform"],
     },
     {
       id: "react",
       flag: "default",
       tags: ["frontend"],
+      products: ["v2"],
       teams: ["frontend"],
     },
     {
       id: "k8s",
       flag: "changed",
       tags: ["infra"],
+      products: ["v3"],
       teams: ["platform"],
     },
     {
       id: "docker",
       flag: "new",
       tags: ["infra"],
+      products: ["v3"],
       teams: ["devops"],
     },
   ]),
@@ -67,6 +71,7 @@ describe("RadarHighlightContext", () => {
     expect(result.current.filterActive).toBe(false);
     expect(result.current.activeFlags.size).toBe(0);
     expect(result.current.activeTags.size).toBe(0);
+    expect(result.current.activeProducts.size).toBe(0);
     expect(result.current.activeTeams.size).toBe(0);
   });
 
@@ -130,6 +135,22 @@ describe("RadarHighlightContext", () => {
     expect(result.current.activeTags.size).toBe(0);
   });
 
+  it("toggleProduct adds and removes a product from the active set", () => {
+    const { result } = renderHook(() => useRadarHighlight(), { wrapper });
+
+    act(() => {
+      result.current.toggleProduct("v2");
+    });
+
+    expect(result.current.activeProducts.has("v2")).toBe(true);
+
+    act(() => {
+      result.current.toggleProduct("v2");
+    });
+
+    expect(result.current.activeProducts.size).toBe(0);
+  });
+
   it("toggleTeam adds and removes a team from the active set", () => {
     const { result } = renderHook(() => useRadarHighlight(), { wrapper });
 
@@ -165,6 +186,16 @@ describe("RadarHighlightContext", () => {
     });
 
     expect(result.current.highlightedIds).toEqual(["ts", "react"]);
+  });
+
+  it("derives highlighted ids from a single active product", () => {
+    const { result } = renderHook(() => useRadarHighlight(), { wrapper });
+
+    act(() => {
+      result.current.toggleProduct("v3");
+    });
+
+    expect(result.current.highlightedIds).toEqual(["k8s", "docker"]);
   });
 
   it("derives highlighted ids from a single active team", () => {
@@ -252,6 +283,7 @@ describe("RadarHighlightContext", () => {
     act(() => {
       result.current.toggleFlag("new");
       result.current.toggleTag("frontend");
+      result.current.toggleProduct("v2");
       result.current.toggleTeam("platform");
     });
 
@@ -263,6 +295,7 @@ describe("RadarHighlightContext", () => {
 
     expect(result.current.activeFlags.size).toBe(0);
     expect(result.current.activeTags.size).toBe(0);
+    expect(result.current.activeProducts.size).toBe(0);
     expect(result.current.activeTeams.size).toBe(0);
     expect(result.current.highlightedIds).toEqual([]);
   });
@@ -289,6 +322,7 @@ describe("RadarHighlightContext", () => {
     act(() => {
       result.current.toggleFlag("new");
       result.current.toggleTag("frontend");
+      result.current.toggleProduct("v2");
     });
 
     // The state→URL effect runs asynchronously after render
@@ -301,16 +335,22 @@ describe("RadarHighlightContext", () => {
     const query = lastCall[0].query;
     expect(query.flags).toBe("new");
     expect(query.tags).toBe("frontend");
+    expect(query.products).toBe("v2");
     expect(query.teams).toBeUndefined();
   });
 
   it("hydrates filter state from URL query params on mount", () => {
-    mockRouter.query = { flags: "changed", teams: "platform" };
+    mockRouter.query = {
+      flags: "changed",
+      products: "v3",
+      teams: "platform",
+    };
 
     const { result } = renderHook(() => useRadarHighlight(), { wrapper });
 
     // URL→state effect fires synchronously on mount with the initial query
     expect(result.current.activeFlags.has("changed")).toBe(true);
+    expect(result.current.activeProducts.has("v3")).toBe(true);
     expect(result.current.activeTeams.has("platform")).toBe(true);
     expect(result.current.activeTags.size).toBe(0);
     expect(result.current.highlightedIds).toEqual(["k8s"]);

--- a/packages/techradar/src/lib/__tests__/config.test.ts
+++ b/packages/techradar/src/lib/__tests__/config.test.ts
@@ -49,6 +49,9 @@ describe("config module", () => {
       expect(config.toggles.showSearch).toBe(true);
       expect(config.toggles.showChart).toBe(true);
       expect(config.toggles.showTagFilter).toBe(true);
+      expect(config.toggles.showFilterOnSegmentPage).toBe(
+        defaultConfig.toggles.showFilterOnSegmentPage,
+      );
       expect(config.toggles.showTeamFilter).toBe(true);
     });
 
@@ -150,6 +153,9 @@ describe("config deep merge (with partial user config)", () => {
     expect(result.toggles.showChart).toBe(false);
     expect(result.toggles.showSearch).toBe(true);
     expect(result.toggles.showTagFilter).toBe(true);
+    expect(result.toggles.showFilterOnSegmentPage).toBe(
+      defaultConfig.toggles.showFilterOnSegmentPage,
+    );
   });
 
   it("partial labels override preserves other labels", () => {

--- a/packages/techradar/src/lib/__tests__/data.test.ts
+++ b/packages/techradar/src/lib/__tests__/data.test.ts
@@ -11,6 +11,7 @@ const _mockItems: Item[] = [
     segment: "languages-and-frameworks",
     flag: Flag.Default,
     tags: ["language"],
+    products: ["v2"],
     release: "2024-03",
     position: [0.3, 0.2],
     teams: ["platform", "frontend"],
@@ -28,6 +29,7 @@ const _mockItems: Item[] = [
     segment: "languages-and-frameworks",
     flag: Flag.New,
     tags: ["frontend"],
+    products: ["v2", "v3"],
     release: "2024-03",
     position: [0.5, 0.6],
     teams: ["frontend"],
@@ -42,6 +44,7 @@ const _mockItems: Item[] = [
     segment: "platforms-and-operations",
     flag: Flag.Changed,
     tags: ["infrastructure"],
+    products: ["v3"],
     release: "2024-01",
     position: [0.7, 0.8],
     teams: ["platform"],
@@ -72,6 +75,7 @@ vi.mock("../../../data/data.json", () => ({
         segment: "languages-and-frameworks",
         flag: "default",
         tags: ["language"],
+        products: ["v2"],
         release: "2024-03",
         position: [0.3, 0.2],
         teams: ["platform", "frontend"],
@@ -89,6 +93,7 @@ vi.mock("../../../data/data.json", () => ({
         segment: "languages-and-frameworks",
         flag: "new",
         tags: ["frontend"],
+        products: ["v2", "v3"],
         release: "2024-03",
         position: [0.5, 0.6],
         teams: ["frontend"],
@@ -103,6 +108,7 @@ vi.mock("../../../data/data.json", () => ({
         segment: "platforms-and-operations",
         flag: "changed",
         tags: ["infrastructure"],
+        products: ["v3"],
         release: "2024-01",
         position: [0.7, 0.8],
         teams: ["platform"],
@@ -220,6 +226,7 @@ import {
   getItemTrajectories,
   getJsUrl,
   getLabel,
+  getProducts,
   getReleases,
   getRing,
   getRings,
@@ -309,6 +316,12 @@ describe("getTags", () => {
   });
 });
 
+describe("getProducts", () => {
+  it("derives a sorted unique product list for legacy generated data", () => {
+    expect(getProducts()).toEqual(["v2", "v3"]);
+  });
+});
+
 describe("getTeams", () => {
   it("returns sorted unique teams", () => {
     const teams = getTeams();
@@ -391,6 +404,11 @@ describe("getFilteredItems", () => {
     const items = getFilteredItems(undefined, undefined, "new");
     expect(items).toHaveLength(1);
     expect(items[0].id).toBe("react");
+  });
+
+  it("filters by product", () => {
+    const items = getFilteredItems(undefined, undefined, undefined, "v3");
+    expect(items.map((item) => item.id)).toEqual(["react", "kubernetes"]);
   });
 });
 

--- a/packages/techradar/src/lib/data.ts
+++ b/packages/techradar/src/lib/data.ts
@@ -11,9 +11,10 @@ import { assetUrl } from "@/lib/utils";
 import rawData from "../../data/data.json";
 import config from "./config";
 
-const data = rawData as {
+const data = rawData as unknown as {
   releases: string[];
   tags: string[];
+  products?: string[];
   items: Item[];
 };
 
@@ -62,6 +63,20 @@ export function getTags(): string[] {
   return data.tags;
 }
 
+export function getProducts(): string[] {
+  if (data.products) return data.products;
+
+  const productsSet = new Set<string>();
+  data.items.forEach((item) => {
+    if (item.products) {
+      item.products.forEach((product) => {
+        productsSet.add(product);
+      });
+    }
+  });
+  return Array.from(productsSet).sort();
+}
+
 export function getTeams(): string[] {
   const teamsSet = new Set<string>();
   data.items.forEach((item) => {
@@ -98,12 +113,14 @@ export function getFilteredItems(
   tag?: string,
   team?: string,
   flag?: string,
+  product?: string,
 ): Item[] {
   return getItems().filter(
     (item) =>
       (!tag || item.tags?.includes(tag)) &&
       (!team || item.teams?.includes(team)) &&
-      (!flag || item.flag === flag),
+      (!flag || item.flag === flag) &&
+      (!product || item.products?.includes(product)),
   );
 }
 

--- a/packages/techradar/src/lib/format.ts
+++ b/packages/techradar/src/lib/format.ts
@@ -102,6 +102,7 @@ export function searchableTextFor(item: Item): string {
     item.title,
     item.summary ?? "",
     ...(item.tags ?? []),
+    ...(item.products ?? []),
     ...(item.teams ?? []),
   ]
     .join(" ")

--- a/packages/techradar/src/lib/theme/schema.ts
+++ b/packages/techradar/src/lib/theme/schema.ts
@@ -26,6 +26,7 @@ export type ThemeCssVariableKey = (typeof CHROME_CSS_VARIABLE_KEYS)[number];
 export const CHIP_KINDS = [
   "status",
   "tag",
+  "product",
   "team",
   "team-added",
   "team-removed",
@@ -101,6 +102,7 @@ export const ThemeJsonSchema = z
       .object({
         status: cssVariableValueSchema,
         tag: cssVariableValueSchema,
+        product: cssVariableValueSchema.optional(),
         team: cssVariableValueSchema,
         "team-added": cssVariableValueSchema,
         "team-removed": cssVariableValueSchema,
@@ -148,7 +150,7 @@ export const ThemeJsonSchema = z
     if (theme.chips) {
       for (const kind of CHIP_KINDS) {
         assertModeCoverage(
-          theme.chips[kind],
+          theme.chips[kind] ?? theme.chips.tag,
           theme.supports,
           ["chips", kind],
           ctx,

--- a/packages/techradar/src/lib/types.ts
+++ b/packages/techradar/src/lib/types.ts
@@ -34,6 +34,7 @@ export interface Item {
   segment: string;
   flag: Flag;
   tags?: string[];
+  products?: string[];
   release: Release;
   revisions?: Revision[];
   position: [x: number, y: number];

--- a/packages/techradar/src/pages/[segment]/index.tsx
+++ b/packages/techradar/src/pages/[segment]/index.tsx
@@ -7,6 +7,7 @@ import type { GetStaticPaths, GetStaticProps } from "next";
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { RadarFilters } from "@/components/RadarFilters/RadarFilters";
 import { SegmentRadar } from "@/components/SegmentRadar/SegmentRadar";
 import { SeoHead } from "@/components/SeoHead/SeoHead";
 import { blipSvgMap } from "@/lib/blipIcons";
@@ -16,6 +17,7 @@ import {
   getRings,
   getSegment,
   getSegments,
+  getToggle,
   groupItemsByRing,
   sortByFeaturedAndTitle,
 } from "@/lib/data";
@@ -36,7 +38,8 @@ const SegmentPage: CustomPage<SegmentPageProps> = ({ segmentId }) => {
   const allSegments = getSegments();
   const rings = getRings();
   const chartConfig = getChartConfig();
-  const { setHighlight } = useRadarHighlight();
+  const showFiltersOnSegmentPage = getToggle("showFilterOnSegmentPage");
+  const { filterMatchIds, hasFilter, setHighlight } = useRadarHighlight();
   const { theme } = useTheme();
 
   const items = segment
@@ -44,7 +47,11 @@ const SegmentPage: CustomPage<SegmentPageProps> = ({ segmentId }) => {
     : [];
   const featuredItems = items.filter((item) => item.featured);
 
-  const ringGroups = groupItemsByRing(items);
+  const visibleItems =
+    showFiltersOnSegmentPage && hasFilter
+      ? items.filter((item) => filterMatchIds.has(item.id))
+      : items;
+  const ringGroups = groupItemsByRing(visibleItems);
 
   const [activeRings, setActiveRings] = useState<Set<string>>(new Set());
   const ringRefs = useRef<Map<string, HTMLElement>>(new Map());
@@ -156,6 +163,11 @@ const SegmentPage: CustomPage<SegmentPageProps> = ({ segmentId }) => {
               items={featuredItems}
               activeRings={activeRings}
             />
+            {showFiltersOnSegmentPage && (
+              <div className={styles.filters}>
+                <RadarFilters />
+              </div>
+            )}
           </div>
         </div>
 

--- a/packages/techradar/src/pages/[segment]/segment.module.scss
+++ b/packages/techradar/src/pages/[segment]/segment.module.scss
@@ -20,6 +20,10 @@
   max-width: 100%;
 }
 
+.filters {
+  margin-top: $pds-spacing-fluid-small;
+}
+
 .content {
   min-width: 0;
 }

--- a/packages/techradar/src/pages/_document.tsx
+++ b/packages/techradar/src/pages/_document.tsx
@@ -73,7 +73,7 @@ function buildThemeBlock(theme: ThemeManifest, counts: PaletteCounts): string {
 
   if (theme.chips) {
     for (const kind of CHIP_KINDS) {
-      const chipValue = theme.chips[kind];
+      const chipValue = theme.chips[kind] ?? theme.chips.tag;
       baseVars.push(`--rtk-chip-${kind}-bg: ${toCssValue(chipValue)}`);
       baseVars.push(
         `--rtk-chip-${kind}-fg: ${toReadableForegroundCssValue(chipValue)}`,


### PR DESCRIPTION
## Summary

- add an optional `products` taxonomy to radar frontmatter, generated data, search, detail chips, and filters
- add `showProductFilter` and `showFilterOnSegmentPage` toggles, both disabled by default
- preserve active status, tag, product, and team filters when navigating from the radar to segment pages
- add product chip colors to built-in themes and document the new configuration/frontmatter fields
- expand unit coverage for product parsing, filtering, URL synchronization, single-select behavior, and rendering
- include small Biome/TypeScript cleanup fixes from the original patch

## Bundle impact

The segment-page filter UI increases the static output by approximately 7.7 KB of JavaScript and 0.2 KB of CSS. The explicit limits are raised by 10,000 JS bytes and 500 CSS bytes; the compressed bundle-growth gate remains within its 5% allowance at 0.80%.

## Validation

- `pnpm install`
- `pnpm --filter @porscheofficial/porschedigital-technology-radar run build:data`
- `pnpm --filter @porscheofficial/porschedigital-technology-radar run build:icons`
- `pnpm --filter @porscheofficial/porschedigital-technology-radar run test`
- `pnpm --filter @porscheofficial/porschedigital-technology-radar run typecheck`
- `pnpm --filter @porscheofficial/porschedigital-technology-radar run build`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` — 755 framework tests and 75 scaffolder tests passed
- `pnpm run build`
- `pnpm run check:arch`
- `pnpm run check:quality`
- `pnpm run check:a11y`
- `pnpm run check:build`
- dependency-license and sanitization security checks passed

The local `osv-scanner` and `trufflehog` binaries were unavailable, so their two local security arms could not run; the corresponding CI security workflows remain authoritative.
