### PR TITLE
replace hardcoded ring names with "allRings" in legend of changelog

### DIFF
--- a/packages/techradar/src/pages/changelog.tsx
+++ b/packages/techradar/src/pages/changelog.tsx
@@ -201,8 +201,8 @@ const Changelog: CustomPage = () => {
 
         <div className={styles.matrixFooter}>
           <div className={styles.matrixLegend}>
-            {["adopt", "trial", "assess", "hold"].map((ringId) => {
-              const ring = getRing(ringId);
+            {allRings.map((ring) => {
+              const ringId = ring.id;
               if (!ring) return null;
               return (
                 <span key={ringId} className={styles.legendItem}>


### PR DESCRIPTION
The rings are hardcoded in file `src/pages/changelog.tsx` as array `["adopt", "trial", "assess", "hold"]`. This patch replaces the array by the variable `allRings` and changes the rest of the line and  the next line accordingly.

## ✅ Checks
- [X] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
