### PR TITLE
fix: repair main after three red auto-merges

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
 
   "vcs": {
     "enabled": true,
@@ -33,7 +33,7 @@
 
   "linter": {
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": { "useUniqueElementIds": "off" },
       "performance": { "noImgElement": "off" },
       "security": { "noBlankTarget": "off" },
@@ -95,6 +95,18 @@
         "rules": {
           "suspicious": { "noExplicitAny": "off" },
           "style": { "useNamingConvention": "off" }
+        }
+      }
+    },
+    {
+      // Biome 2.5.6 started applying this JSX rule to standalone .svg assets.
+      // These are served as images or compiled into Icon components, so their
+      // accessible name comes from the consuming element, not an inline
+      // <title>. The rule stays on for SVG written inline in JSX.
+      "includes": ["**/*.svg"],
+      "linter": {
+        "rules": {
+          "a11y": { "noSvgWithoutTitle": "off" }
         }
       }
     }

--- a/packages/techradar/bin/initFlow.ts
+++ b/packages/techradar/bin/initFlow.ts
@@ -127,8 +127,8 @@ export function slugify(input: string): string {
     .trim()
     .replace(/[\s_]+/g, "-")
     .replace(SLUG_RE, "")
-    .replace(/^-+|-+$/g, "")
-    .replace(/-{2,}/g, "-");
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
 }
 
 export function titleCase(input: string): string {

--- a/packages/techradar/bundle-budget.json
+++ b/packages/techradar/bundle-budget.json
@@ -1,6 +1,6 @@
 {
   "$schema": "Hand-edited bundle thresholds. Bump only when a deliberate cost is justified.",
-  "maxTotalJsBytes": 2710000,
-  "maxTotalCssBytes": 77000,
+  "maxTotalJsBytes": 2730000,
+  "maxTotalCssBytes": 140000,
   "maxChunkBytes": 293000
 }

--- a/packages/techradar/scripts/checkConfigReadmeSync.ts
+++ b/packages/techradar/scripts/checkConfigReadmeSync.ts
@@ -184,7 +184,7 @@ for (const key of configKeys) {
   if (!pattern.test(readme)) missingInReadme.push(key);
 }
 
-const schemaFieldRegex = /^\s*([a-zA-Z_]\w*):\s*z\.[a-zA-Z]/gm;
+const schemaFieldRegex = /^[ \t]*([a-zA-Z_]\w*):[ \t]*z\.[a-zA-Z]/gm;
 const schemaFields = [...frontmatter.matchAll(schemaFieldRegex)].map(
   (m) => m[1],
 );

--- a/packages/techradar/scripts/checkDocCoverage.ts
+++ b/packages/techradar/scripts/checkDocCoverage.ts
@@ -61,7 +61,7 @@ const npmScripts = new Set(Object.keys(pkg.scripts ?? {}));
 const agentsFiles = walk(walkRoot).filter((f) => /AGENTS\.md$/.test(f));
 
 const errors: string[] = [];
-const checkedRe = /\(Checked:\s*([^)]+?)\)/g;
+const checkedRe = /\(Checked:([^)]+)\)/g;
 const fileArrowRe =
   /`(\.?[\w./-]+\.(?:cjs|js|ts|tsx))`\s*(?:→|->)\s*`([^`]+)`/g;
 const npmRe = /`pnpm run ([\w:-]+)`/g;

--- a/packages/techradar/scripts/checkWikiLinks.ts
+++ b/packages/techradar/scripts/checkWikiLinks.ts
@@ -22,7 +22,7 @@ import { preScanBlipLookup } from "./buildData";
 const root = path.resolve(__dirname, "..");
 const radarDir = path.join(root, "data/radar");
 
-const WIKI_LINK_RE = /\[\[([^\]|]+?)(?:\|[^\]]+?)?\]\]/g;
+const WIKI_LINK_RE = /\[\[([^[\]|]+)(?:\|[^[\]]+)?\]\]/g;
 
 const lookup = preScanBlipLookup(radarDir);
 const errors: string[] = [];

--- a/packages/techradar/scripts/remarkWikiLink.ts
+++ b/packages/techradar/scripts/remarkWikiLink.ts
@@ -39,7 +39,7 @@ export function resetUnresolvedCount(): void {
 // Plugin
 // ---------------------------------------------------------------------------
 
-const WIKI_LINK_RE = /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
+const WIKI_LINK_RE = /\[\[([^[\]|]+)(?:\|([^[\]]+))?\]\]/g;
 
 /**
  * Remark plugin: resolve `[[id]]` and `[[id|label]]` wiki-links to internal

--- a/packages/techradar/src/components/Badge/__tests__/Badge.test.tsx
+++ b/packages/techradar/src/components/Badge/__tests__/Badge.test.tsx
@@ -51,15 +51,14 @@ describe("Badge", () => {
     expect(screen.getByText("Adopt")).toBeInTheDocument();
   });
 
-  it.each([
-    "small",
-    "medium",
-    "large",
-  ] as const)("applies the %s size class", (size) => {
-    render(<Badge size={size}>Sized</Badge>);
+  it.each(["small", "medium", "large"] as const)(
+    "applies the %s size class",
+    (size) => {
+      render(<Badge size={size}>Sized</Badge>);
 
-    expect(screen.getByText("Sized")).toHaveClass(`size-${size}`);
-  });
+      expect(screen.getByText("Sized")).toHaveClass(`size-${size}`);
+    },
+  );
 
   it("applies the badge color CSS variable", () => {
     render(<Badge color="#93c47d">Colored</Badge>);

--- a/packages/techradar/src/components/ItemDetail/__tests__/ItemDetail.test.tsx
+++ b/packages/techradar/src/components/ItemDetail/__tests__/ItemDetail.test.tsx
@@ -304,13 +304,14 @@ describe("ItemDetail", () => {
   it.each([
     { revisions: undefined, label: "undefined" },
     { revisions: [], label: "empty" },
-  ])("does not render the revision history timeline when revisions are $label", ({
-    revisions,
-  }) => {
-    const { container } = renderItemDetail({ revisions });
+  ])(
+    "does not render the revision history timeline when revisions are $label",
+    ({ revisions }) => {
+      const { container } = renderItemDetail({ revisions });
 
-    expect(container.querySelector(".timeline")).not.toBeInTheDocument();
-  });
+      expect(container.querySelector(".timeline")).not.toBeInTheDocument();
+    },
+  );
 
   it("renders ring changes, initial entries, body changes, and team changes in history groups", () => {
     renderItemDetail({

--- a/packages/techradar/src/lib/__tests__/blipIcons.test.ts
+++ b/packages/techradar/src/lib/__tests__/blipIcons.test.ts
@@ -18,12 +18,13 @@ describe("blipSvgMap", () => {
     expect(value).toMatch(/^data:image\/svg\+xml,/);
   });
 
-  it.each(
-    Object.values(Flag),
-  )("Flag.%s SVG contains a shape element", (flag) => {
-    const svg = decodeURIComponent(blipSvgMap[flag]);
-    expect(svg).toMatch(/<(path|rect|circle)\s/);
-  });
+  it.each(Object.values(Flag))(
+    "Flag.%s SVG contains a shape element",
+    (flag) => {
+      const svg = decodeURIComponent(blipSvgMap[flag]);
+      expect(svg).toMatch(/<(path|rect|circle)\s/);
+    },
+  );
 
   it("New flag uses a path (triangle)", () => {
     const svg = decodeURIComponent(blipSvgMap[Flag.New]);

--- a/packages/techradar/src/lib/data.ts
+++ b/packages/techradar/src/lib/data.ts
@@ -7,7 +7,7 @@ import type {
   Segment,
   VersionDiff,
 } from "@/lib/types";
-import { assetUrl } from "@/lib/utils";
+import { assetUrl, stripTrailingSlashes } from "@/lib/utils";
 import rawData from "../../data/data.json";
 import config from "./config";
 
@@ -131,7 +131,7 @@ export function getImprintUrl() {
 export function getAbsoluteUrl(path: string = "/") {
   if (/^https?:\/\//.test(path)) return path;
   const envBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-  const baseUrl = (envBaseUrl ?? config.baseUrl ?? "").replace(/\/+$/, "");
+  const baseUrl = stripTrailingSlashes(envBaseUrl ?? config.baseUrl ?? "");
   return `${baseUrl}${assetUrl(path)}`;
 }
 

--- a/packages/techradar/src/lib/format.ts
+++ b/packages/techradar/src/lib/format.ts
@@ -44,7 +44,7 @@ export function stripHtml(html: string): string {
   let next = html;
   do {
     prev = next;
-    next = prev.replace(/<[^>]*>/g, "");
+    next = prev.replace(/<[^<>]*>/g, "");
   } while (next !== prev);
   return next.trim();
 }

--- a/packages/techradar/src/lib/utils.ts
+++ b/packages/techradar/src/lib/utils.ts
@@ -70,6 +70,14 @@ function parseHex(hex: string): [number, number, number] | null {
   ];
 }
 
+// Scans backwards instead of using /\/+$/, whose backtracking is quadratic on
+// slash-heavy input (sonarjs/super-linear-regex).
+export function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end--;
+  return value.slice(0, end);
+}
+
 export function assetUrl(path: string) {
   if (/^https?:/.test(path)) return path;
   if (!path.startsWith("/")) path = `/${path}`;
@@ -82,6 +90,6 @@ export function assetUrl(path: string) {
   // tree-shook it by accident).
   const envBase = process.env.NEXT_PUBLIC_BASE_PATH;
   const rawBase = envBase != null ? envBase : config.basePath;
-  const base = rawBase?.replace(/\/+$/, "") || "";
+  const base = rawBase ? stripTrailingSlashes(rawBase) : "";
   return `${base}${path}`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 26.1.0
-        version: 26.1.2
+        version: 26.1.0
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
@@ -2745,6 +2745,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
@@ -8107,7 +8110,7 @@ snapshots:
 
   '@types/jsdom@28.0.3':
     dependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.1.0
       '@types/tough-cookie': 4.0.5
       parse5: 8.0.1
       undici-types: 7.26.0
@@ -8121,6 +8124,10 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/ms@2.1.0': {}
+
+  '@types/node@26.1.0':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/node@26.1.2':
     dependencies:


### PR DESCRIPTION
## Why

Every CI run on `main` has failed since `5f045de8` (10:59 UTC). Four
independent breakages had accumulated, each from a Renovate PR that
auto-merged red — the branch ruleset only gained `required_status_checks`
at 17:19 UTC, so nothing was gating on CI before that.

They masked each other: `pnpm install --frozen-lockfile` is step one of
every job, so nothing downstream ever ran.

## What was broken

**1. Lockfile desync** — `fb092b1 chore(deps): update types` pinned
`@types/node` to `26.1.0` in `packages/create-techradar/package.json`
but left the lockfile resolving `26.1.2`:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with packages/create-techradar/package.json
  The importer resolution is broken at dependency "@types/node":
  version "26.1.2" doesn't satisfy range "26.1.0"
```

**2. Biome 2.4.16 → 2.5.6** (`5f045de`) — the linter `rules.recommended`
key was renamed to `rules.preset`, `it.each()` calls reformat, and
`a11y/noSvgWithoutTitle` now applies to standalone `.svg` files (30 hits
across `data/themes/` and `src/icons/`).

**3. eslint-plugin-sonarjs 4.2.0** (`f303a51`) — eight
`sonarjs/super-linear-regex` errors. CI's `verify` job runs
`check:quality`, so these block just as hard.

**4. Bundle budget exceeded** — CSS 131.7 KB against a 75.2 KB budget,
JS 2650.0 KB against 2646.5 KB.

## What this PR does

- Regenerates `pnpm-lock.yaml` (+9/−2, purely the `@types/node`
  resolution for the `create-techradar` importer).
- Runs `biome migrate`, applies the new formatting, and adds an
  `overrides` entry exempting `**/*.svg` from `noSvgWithoutTitle`. Those
  files are served as images or compiled into Icon components, so their
  accessible name comes from the consuming element; the rule stays on
  for SVG written inline in JSX.
- Rewrites the eight regexes to linear equivalents. Negated classes now
  exclude the delimiter that let a scan run past it, lazy quantifiers
  become greedy where the class already bounds the match, `^\s*` becomes
  `^[ \t]*` so it cannot span lines under `/m`, and the two
  trailing-slash trims use a backward scan instead of `/\/+$/`.
  Behaviour is unchanged — all 757 tests pass.
- Raises the bundle budget, with the attribution below.

## Bundle budget: attribution

Building `origin/main` with **only** the lockfile commit cherry-picked
reproduces CSS 131.7 KB and JS 2649.5 KB. So both overruns are
pre-existing; this branch adds 0.5 KB of JS and no CSS.

35.4% of the CSS (47.8 KB) is Porsche Design System `:lang()` font
overrides — 567 expansions across `ja`, `ko` and seven Chinese locales,
emitted once per component class rather than once at the root.

Raising the thresholds unblocks CI. Collapsing those overrides to a
single root-level declaration touches the SCSS of roughly twelve
components and wants its own visual review, so it is left as follow-up.

## Verification

All 11 required checks pass. Locally `pnpm install --frozen-lockfile`
exits 0 and the full harness is green: `lint`, `typecheck`, `test`,
`check:arch`, `check:quality`, `check:a11y`, `build`, `check:build`,
`check:sec:licenses`, `check:sec:sanitize`.

## Deliberately not included

- **44 Biome warnings** (`noLeakedRender` ×25, `noJsxPropsBind` ×19)
  across ~10 components. Warnings do not fail the build; fixing them is a
  refactor, not a repair.
- **`check:sec:deps`** still reports pre-existing CVEs in
  `pnpm-lock.yaml`. Unchanged from `main`, and not gated in CI.

## Follow-ups

- Collapse the PDS `:lang()` font overrides to a root-level rule and
  lower the CSS budget back down.
- Renovate is emitting `fix(deps):` rather than the configured
  `build(deps):`, because `config:best-practices` pulls in
  `:semanticPrefixFixDepsChoreOthers`, whose *packageRules* override the
  top-level `semanticCommitType`. A minor runtime-dep bump would
  therefore auto-merge and trigger a release.
- Release PRs from release-please carry zero checks, because
  `GITHUB_TOKEN`-raised events do not trigger workflows. Adding
  `workflow_dispatch` to the gating workflows and dispatching it from
  `release-please.yml` would fix this without any new permissions.
