### PR TITLE
ci(deps): correct renovate node rule, record commit-type and required-check decisions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,10 +21,15 @@
   "labels": ["dependencies"],
 
   // commitlint (commitlint.config.js) enforces `scope-enum` at error level and does
-  // NOT allow `deps-dev`. A flat `build(deps):` for every npm update satisfies it, and
-  // keeps release-please from cutting a release per dependency bump — the default
-  // `:semanticPrefixFixDepsChoreOthers` would emit `fix(deps):` for runtime deps,
-  // which release-please treats as releasable.
+  // NOT allow `deps-dev`, so every update carries the flat `deps` scope.
+  //
+  // The commit *type* is mostly decided by `:semanticPrefixFixDepsChoreOthers`
+  // (via config:recommended), whose packageRules override this top-level value:
+  //   fix(deps)   — a shipped `dependencies` range moved, so consumers need a release
+  //   chore(deps) — devDependencies, or a runtime dep where only pnpm-lock.yaml moved
+  //   build(deps) — lock file maintenance; the one case this top-level value sets
+  // That mapping is deliberate: release-please cuts a release exactly when the
+  // published package.json changed. See ADR-0035 — do not flatten it to `build`.
   "semanticCommits": "enabled",
   "semanticCommitType": "build",
   "semanticCommitScope": "deps",
@@ -85,9 +90,12 @@
     // `node-version:` in the workflows and `engines.node` in each package.json
     // encode the *lowest supported* runtime (22). The CI matrix intentionally
     // spans 22/24/26. Renovate would otherwise propose bumping 22 -> 24.
+    //
+    // Must match on `depName`, not `packageName`: the github-runners datasource
+    // reports depName `node` but packageName `actions/node-versions`.
     // ---------------------------------------------------------------------
     {
-      "matchPackageNames": ["node"],
+      "matchDepNames": ["node"],
       "enabled": false,
     },
 

--- a/docs/decisions/0035-renovate-commit-types-track-published-ranges.md
+++ b/docs/decisions/0035-renovate-commit-types-track-published-ranges.md
@@ -1,0 +1,87 @@
+# ADR-0035 — Renovate commit types track the published dependency range
+
+- Status: accepted (amends 0034)
+- Date: 2026-08-05
+
+## Context
+
+ADR-0034 migrated dependency updates from Dependabot to Renovate. It recorded
+that `.github/renovate.json5` sets a flat `semanticCommitType: "build"` so that
+every dependency update lands as `build(deps): …`, and it justified that choice
+as keeping release-please from cutting a release for each dependency bump.
+
+Two weeks of real commits show that is not what happens, and that the recorded
+intent was wrong on the merits.
+
+`config:best-practices` pulls in `config:recommended`, which pulls in
+`:semanticPrefixFixDepsChoreOthers`. That preset supplies its own `packageRules`,
+and package rules are applied after — and therefore override — top-level
+configuration. The effective mapping is:
+
+| Commit type   | Emitted when                                                | Release? |
+| ------------- | ----------------------------------------------------------- | -------- |
+| `fix(deps)`   | a range in a published `dependencies` block moved            | yes      |
+| `chore(deps)` | a devDependency moved, or only `pnpm-lock.yaml` moved        | no       |
+| `build(deps)` | lock file maintenance                                        | no       |
+
+Only the last row is actually set by our top-level value.
+
+Of the 24 dependency commits that reached `main`, exactly two produced
+`fix(deps)`: `@porsche-design-system/components-js` moving from `4.1.0` to
+`4.5.0`, and `satori` moving from `^0.26.0` to `^0.29.0`. Both edited the
+`dependencies` block of `packages/techradar/package.json`, which is published to
+npm. Every other update — including `next`, `react`, `html-react-parser` and
+`@radix-ui/react-dialog`, all of which live in `dependencies` — produced
+`chore(deps)`, because the declared caret range already admitted the new version
+and only the lockfile changed.
+
+That distinction is precisely the one a consumer cares about. A consumer of
+`@porscheofficial/porschedigital-technology-radar` resolves its own dependency
+tree from our published `package.json`; our lockfile is not published. When our
+declared range does not move, there is nothing for a consumer to install and no
+reason to publish. When it does move, withholding the release means the change
+never reaches anyone.
+
+Flattening every update to `build(deps)`, as ADR-0034 described, would have
+suppressed the release for the Porsche Design System bump. The published package
+would have continued to declare `4.1.0` indefinitely while our own repository
+built against `4.5.0`.
+
+## Decision
+
+Renovate's default commit-type mapping stands. `.github/renovate.json5` keeps
+`semanticCommitType: "build"` — it is the correct value for the one case it
+still governs, lock file maintenance — and does not attempt to override
+`:semanticPrefixFixDepsChoreOthers`.
+
+The rule to reason from is: **the commit type tracks whether the published
+dependency range moved, not whether the dependency is a runtime or a development
+one.** A dependency update cuts a release exactly when it changes what a
+consumer would install.
+
+This ADR changes no behaviour. It corrects the rationale recorded in ADR-0034
+and the comment in `.github/renovate.json5`, both of which described a
+configuration that was never in effect and should not be put into effect.
+
+## Consequences
+
+### Good
+
+- Dependency updates that matter to consumers ship to npm without manual
+  intervention; ones that do not, do not generate release noise.
+- The `.github/renovate.json5` comment now matches observable behaviour, so the
+  next reader will not "fix" the config to match a stale description.
+- No release-please or Renovate configuration changes, so no risk of regression.
+
+### Trade-offs / risks
+
+- A `fix(deps)` update that is also eligible for automerge can reach `main` and
+  cut a release without a human in the loop. This is intended — the harness is
+  the gate, not a human — but it means the release cadence is driven by upstream
+  publishing schedules.
+- The mapping lives in an upstream preset. If Renovate changes
+  `:semanticPrefixFixDepsChoreOthers`, our release-triggering behaviour changes
+  with it. The `:configMigration` arm of `config:best-practices` will surface
+  preset changes as a pull request, but the semantics are not pinned.
+- Hand-written commits do not get this treatment. A lockfile-only change
+  committed manually as `fix(deps)` will cut a release; use `chore` for those.

--- a/docs/decisions/0036-require-status-checks-on-main.md
+++ b/docs/decisions/0036-require-status-checks-on-main.md
@@ -1,0 +1,109 @@
+# ADR-0036 — Require status checks on `main` and approve bot-authored release PRs
+
+- Status: accepted
+- Date: 2026-08-05
+
+## Context
+
+The `main` branch has been governed by repository ruleset "Protect main
+(OpenSSF)" since 2026-05-05. It enforced `deletion`, `non_fast_forward`,
+`required_linear_history` and `pull_request` with
+`required_approving_review_count: 0`.
+
+None of those rules consult CI. The branch was protected against force-pushes
+and non-linear history, but a pull request whose entire harness was red could
+still be merged. Nothing surfaced the gap while every merge was human-driven and
+every human waited for the checks.
+
+Enabling Renovate changed that. Renovate enables GitHub auto-merge on
+minor/patch updates, and GitHub auto-merge only waits for checks that are
+*required*. With no required checks, "auto-merge when ready" meant "merge now".
+On 2026-08-04 twelve dependency pull requests merged into `main` between 10:59
+and 17:00 UTC while failing, and left it broken four ways at once:
+
+- `pnpm-lock.yaml` desynchronised from an exact-pinned `@types/node`, so
+  `pnpm install --frozen-lockfile` — the first step of every job — failed;
+- Biome 2.5.6 renamed a linter configuration key and began applying a JSX
+  accessibility rule to standalone `.svg` assets;
+- `eslint-plugin-sonarjs` 4.2.0 added `super-linear-regex`, which flagged eight
+  existing patterns;
+- the CSS bundle exceeded its budget.
+
+Each masked the next. Repairing them took a dedicated pull request.
+
+Adding required checks fixes this, but interacts badly with one pull request:
+the release-please PR. `.github/workflows/release-please.yml` authenticates with
+`secrets.GITHUB_TOKEN`, and GitHub places workflow runs triggered by a
+`GITHUB_TOKEN`-authored pull request into an approval-required state rather than
+running them. Such a run reports no check runs at all, so every required context
+stays pending forever and the release PR can never merge. Because the ruleset
+has no bypass actors, an administrator cannot override it either.
+
+## Decision
+
+Add `required_status_checks` to the existing ruleset, covering the nine contexts
+that run on pull requests:
+
+- `Lint, types, tests, build`
+- `Bootstrap fresh clone`
+- `Scaffolder to framework e2e (Node 22)`, `(Node 24)`, `(Node 26)`
+- `Analyze (javascript-typescript)`
+- `OSV-Scanner (npm advisories)`
+- `TruffleHog (committed secrets)`
+- `rehype-sanitize wiring + XSS regression`
+
+`strict_required_status_checks_policy` stays `false`. Requiring branches to be
+up to date with `main` would mean every merge invalidates every other open pull
+request; with a Renovate backlog in the dozens that serialises the queue and
+defeats auto-merge.
+
+Jobs that only run on `push` to `main` — `build`, `deploy`, `publish`,
+`release-please`, `OpenSSF Scorecard` — are deliberately excluded. A required
+context that never reports on a pull request blocks every pull request.
+
+Approvals stay at zero. The harness is the gate; requiring a reviewer would stop
+auto-merge without adding a check that CI does not already perform.
+
+The release-please pull request is unblocked by approving its pending workflow
+runs — the **Approve workflows to run** button in the merge box, or
+`POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve`. This is a manual
+step, once per release, performed by someone with write access.
+
+## Consequences
+
+### Good
+
+- A pull request cannot merge into `main` with a failing harness, whether it is
+  opened by a human, by Renovate, or by auto-merge.
+- Renovate's auto-merge becomes safe: it now queues behind the harness instead
+  of racing it.
+- Administrators are not exempt, so the guarantee holds uniformly.
+
+### Trade-offs / risks
+
+- Every release requires a human to approve the release PR's workflow runs.
+  Forgetting leaves the release PR permanently blocked, which is visible but
+  silent — nothing fails, the PR simply never becomes mergeable.
+- `strict: false` means a pull request can merge against a slightly stale
+  `main`. Two individually-green changes can still combine into a red `main`;
+  the `push` run on `main` is what catches that.
+- The required context list is coupled to job names. Renaming a job in
+  `.github/workflows/` without updating the ruleset silently drops that gate, or
+  blocks every pull request if the old name is still required.
+
+### Alternatives considered
+
+- **Give release-please a GitHub App or personal access token.** Pull requests
+  authored by either run workflows without the approval prompt. Installing an
+  App requires organisation-owner rights we do not have, which is why Renovate
+  itself was installed as a marketplace app rather than self-hosted; a
+  fine-grained token needs the same approval. Rejected as unavailable.
+- **Dispatch the workflows from `release-please.yml`.** `workflow_dispatch` is
+  an explicit exception to the `GITHUB_TOKEN` suppression rule, so the job could
+  trigger its own checks. Rejected: it exists specifically to circumvent a
+  deliberate safety gate on bot-authored code, it cannot be tested before it is
+  on the default branch, and it would spread release plumbing across four
+  workflow files to save one click per release.
+- **Add a bypass actor to the ruleset.** One API call, but release PRs would
+  then merge untested — reinstating the exact failure mode this ADR exists to
+  close.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -67,7 +67,9 @@ ADRs cite the *decisions behind those rules*.
 | 0031 | Gate `next.config.js` dev-only branches on monorepo execution context | accepted |
 | 0032 | `create-techradar` peer version policy | accepted |
 | 0033 | Dereference symlinks when copying the package into the shadow workspace | accepted |
-| 0034 | Migrate dependency updates from Dependabot to Renovate | accepted (amends 0017) |
+| 0034 | Migrate dependency updates from Dependabot to Renovate | accepted (amends 0017, amended by 0035) |
+| 0035 | Renovate commit types track the published dependency range | accepted (amends 0034) |
+| 0036 | Require status checks on `main` and approve bot-authored release PRs | accepted |
 
 ## When to write a new ADR
 


### PR DESCRIPTION
Follow-up to #207 (Dependabot → Renovate). Two weeks of real Renovate commits
exposed one config bug and one incorrect decision record. Also documents the
branch-protection change made on 2026-08-04.

## 1. The `node` disable rule never matched

`.github/renovate.json5` carried a rule meant to keep Renovate away from the
`node-version:` pins, because 22 is the *lowest supported* runtime and the CI
matrix deliberately spans 22/24/26. It matched on `matchPackageNames: ["node"]`.

The `github-runners` datasource reports `depName: node` but
`packageName: actions/node-versions`, so the rule matched nothing — which is why
#243 (`ci(deps): update dependency node to v24`) exists, rewriting `node-version`
in four workflows. Switched to `matchDepNames`. #243 will be closed.

## 2. `build(deps)` for everything was the wrong call — and never happened

ADR-0034 recorded a flat `semanticCommitType: "build"` so that dependency bumps
would not cut releases. That never took effect: `:semanticPrefixFixDepsChoreOthers`
(via `config:recommended`) supplies `packageRules`, which override top-level
config.

Good thing, because the default mapping is the correct one:

| Type | Emitted when | Release? |
| --- | --- | --- |
| `fix(deps)` | a published `dependencies` range moved | yes |
| `chore(deps)` | devDependency, or runtime dep where only the lockfile moved | no |
| `build(deps)` | lock file maintenance | no |

Our lockfile is not published; consumers resolve from our `package.json`. So the
type tracks exactly the thing that matters: did what a consumer installs change?

Of 24 dependency commits on `main`, two produced `fix(deps)` —
`@porsche-design-system/components-js` `4.1.0` → `4.5.0` and `satori`
`^0.26.0` → `^0.29.0`. Both edited the published `dependencies` block. Everything
else, including `next` and `react` (also runtime deps), correctly produced
`chore(deps)` because only `pnpm-lock.yaml` moved.

Had the flat `build` actually applied, the published package would still declare
PDS `4.1.0` while we build against `4.5.0`.

**No behaviour changes here** — only the comment and ADR-0035.

## 3. Required status checks (ADR-0036)

Ruleset "Protect main (OpenSSF)" enforced linear history and pull requests but
never consulted CI. Renovate's auto-merge only waits for *required* checks, so on
2026-08-04 twelve red PRs merged between 10:59–17:00 UTC and broke `main` four
ways (lockfile desync, Biome 2.5.6 config rename, new `sonarjs/super-linear-regex`,
CSS budget). Nine PR-scoped contexts are now required; `strict` stays off so a
large Renovate queue does not serialise.

ADR-0036 also records why release PRs need a manual nudge: GitHub places workflow
runs from `GITHUB_TOKEN`-authored PRs into an **approval-required** state, which
reports *zero* check runs — so every required context stays pending forever.
Approving the runs on #208 took it from 0 checks to 10. Alternatives (GitHub App
/ PAT, `workflow_dispatch` self-dispatch, ruleset bypass actor) are documented and
rejected in the ADR.

## Verification

- `renovate-config-validator --strict` → `Config validated successfully`
- `lint`, `check:quality`, `check:arch` → pass (`check:arch` confirms 36 ADRs, unique)
- No source files touched; `.github/renovate.json5` + three docs files only
